### PR TITLE
fix destructuring arguments

### DIFF
--- a/@packages/parse-function/src/plugins/destructured-args.js
+++ b/@packages/parse-function/src/plugins/destructured-args.js
@@ -1,0 +1,20 @@
+/* eslint-disable no-param-reassign, unicorn/consistent-function-scoping */
+
+export default () => (node, result) => {
+  result.destructuredArgs = result.destructuredArgs || [];
+
+  node.params.forEach((param) => {
+    if (
+      param.type === 'ObjectPattern' &&
+      param.properties &&
+      param.properties.length > 0
+    ) {
+      param.properties.forEach((prop) => {
+        const { name } = prop.value;
+        result.destructuredArgs.push(name);
+      });
+    }
+  });
+
+  return result;
+};

--- a/@packages/parse-function/src/plugins/initial.js
+++ b/@packages/parse-function/src/plugins/initial.js
@@ -3,6 +3,7 @@
 import body from './body';
 import props from './props';
 import params from './params';
+import destructuredArgs from './destructured-args';
 
 /**
  * > Default plugin that handles regular functions,
@@ -36,6 +37,7 @@ export default (app) => (node, result) => {
 
   result = props(app)(node, result);
   result = params(app)(node, result);
+  result = destructuredArgs(app)(node, result);
   result = body(app)(node, result);
 
   // eslint-disable-next-line consistent-return

--- a/@packages/parse-function/src/plugins/params.js
+++ b/@packages/parse-function/src/plugins/params.js
@@ -18,6 +18,18 @@ export default () => (node, result) => {
     const restArgName =
       param.type === 'RestElement' && param.argument && param.argument.name;
 
+    if (
+      param.type === 'ObjectPattern' &&
+      param.properties &&
+      param.properties.length > 0
+    ) {
+      param.properties.forEach((prop) => {
+        const { name } = prop.value;
+        result.args.push(name);
+      });
+      return;
+    }
+
     const name = param.name || defaultArgsName || restArgName;
 
     result.args.push(name);

--- a/@packages/parse-function/src/plugins/params.js
+++ b/@packages/parse-function/src/plugins/params.js
@@ -18,18 +18,6 @@ export default () => (node, result) => {
     const restArgName =
       param.type === 'RestElement' && param.argument && param.argument.name;
 
-    if (
-      param.type === 'ObjectPattern' &&
-      param.properties &&
-      param.properties.length > 0
-    ) {
-      param.properties.forEach((prop) => {
-        const { name } = prop.value;
-        result.args.push(name);
-      });
-      return;
-    }
-
     const name = param.name || defaultArgsName || restArgName;
 
     result.args.push(name);

--- a/@packages/parse-function/test/__snapshots__/index.js.snap
+++ b/@packages/parse-function/test/__snapshots__/index.js.snap
@@ -13,6 +13,7 @@ Object {
     "cb": undefined,
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": false,
@@ -39,6 +40,7 @@ Object {
     "callback": undefined,
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": false,
@@ -61,6 +63,7 @@ Object {
   "defaults": Object {
     "c": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": false,
@@ -83,6 +86,7 @@ Object {
   "defaults": Object {
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": false,
@@ -101,6 +105,7 @@ Object {
   "args": Array [],
   "body": "",
   "defaults": Object {},
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": false,
@@ -123,6 +128,7 @@ Object {
   "defaults": Object {
     "a": "false",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": false,
@@ -145,6 +151,7 @@ Object {
   "defaults": Object {
     "a": "null",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": false,
@@ -167,6 +174,7 @@ Object {
   "defaults": Object {
     "a": "\\"bar\\"",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": false,
@@ -191,6 +199,7 @@ Object {
     "a": undefined,
     "b": "true",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": false,
@@ -213,6 +222,7 @@ Object {
   "defaults": Object {
     "a": "1",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": false,
@@ -226,7 +236,33 @@ Object {
 }
 `;
 
-exports[`#11 - babel (default) - function namedFn (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
+exports[`#11 - babel (default) - function ({x, y}) {} 1`] = `
+Object {
+  "args": Array [
+    false,
+  ],
+  "body": "",
+  "defaults": Object {
+    "false": undefined,
+  },
+  "destructuredArgs": Array [
+    "x",
+    "y",
+  ],
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "false",
+  "value": "function ({x, y}) {}",
+}
+`;
+
+exports[`#12 - babel (default) - function namedFn (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -239,6 +275,7 @@ Object {
     "cb": undefined,
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -252,7 +289,7 @@ Object {
 }
 `;
 
-exports[`#12 - babel (default) - function namedFn (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
+exports[`#13 - babel (default) - function namedFn (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
 Object {
   "args": Array [
     "b",
@@ -265,6 +302,7 @@ Object {
     "callback": undefined,
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -278,7 +316,7 @@ Object {
 }
 `;
 
-exports[`#13 - babel (default) - function namedFn (c) {return c * 3} 1`] = `
+exports[`#14 - babel (default) - function namedFn (c) {return c * 3} 1`] = `
 Object {
   "args": Array [
     "c",
@@ -287,6 +325,7 @@ Object {
   "defaults": Object {
     "c": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -300,7 +339,7 @@ Object {
 }
 `;
 
-exports[`#14 - babel (default) - function namedFn (...restArgs) {return 321} 1`] = `
+exports[`#15 - babel (default) - function namedFn (...restArgs) {return 321} 1`] = `
 Object {
   "args": Array [
     "restArgs",
@@ -309,6 +348,7 @@ Object {
   "defaults": Object {
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -322,11 +362,12 @@ Object {
 }
 `;
 
-exports[`#15 - babel (default) - function namedFn () {} 1`] = `
+exports[`#16 - babel (default) - function namedFn () {} 1`] = `
 Object {
   "args": Array [],
   "body": "",
   "defaults": Object {},
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -340,7 +381,7 @@ Object {
 }
 `;
 
-exports[`#16 - babel (default) - function namedFn(a = (true, false)) {} 1`] = `
+exports[`#17 - babel (default) - function namedFn(a = (true, false)) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -349,6 +390,7 @@ Object {
   "defaults": Object {
     "a": "false",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -362,7 +404,7 @@ Object {
 }
 `;
 
-exports[`#17 - babel (default) - function namedFn(a = (true, null)) {} 1`] = `
+exports[`#18 - babel (default) - function namedFn(a = (true, null)) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -371,6 +413,7 @@ Object {
   "defaults": Object {
     "a": "null",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -384,7 +427,7 @@ Object {
 }
 `;
 
-exports[`#18 - babel (default) - function namedFn(a = (true, "bar")) {} 1`] = `
+exports[`#19 - babel (default) - function namedFn(a = (true, "bar")) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -393,6 +436,7 @@ Object {
   "defaults": Object {
     "a": "\\"bar\\"",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -406,7 +450,7 @@ Object {
 }
 `;
 
-exports[`#19 - babel (default) - function namedFn(a, b = (i++, true)) {} 1`] = `
+exports[`#20 - babel (default) - function namedFn(a, b = (i++, true)) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -417,6 +461,7 @@ Object {
     "a": undefined,
     "b": "true",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -430,7 +475,7 @@ Object {
 }
 `;
 
-exports[`#20 - babel (default) - function namedFn(a = 1) {} 1`] = `
+exports[`#21 - babel (default) - function namedFn(a = 1) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -439,6 +484,7 @@ Object {
   "defaults": Object {
     "a": "1",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -452,7 +498,33 @@ Object {
 }
 `;
 
-exports[`#21 - babel (default) - function * namedFn (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
+exports[`#22 - babel (default) - function namedFn({x, y}) {} 1`] = `
+Object {
+  "args": Array [
+    false,
+  ],
+  "body": "",
+  "defaults": Object {
+    "false": undefined,
+  },
+  "destructuredArgs": Array [
+    "x",
+    "y",
+  ],
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "false",
+  "value": "function namedFn({x, y}) {}",
+}
+`;
+
+exports[`#23 - babel (default) - function * namedFn (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -465,6 +537,7 @@ Object {
     "cb": undefined,
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -478,7 +551,7 @@ Object {
 }
 `;
 
-exports[`#22 - babel (default) - function * namedFn (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
+exports[`#24 - babel (default) - function * namedFn (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
 Object {
   "args": Array [
     "b",
@@ -491,6 +564,7 @@ Object {
     "callback": undefined,
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -504,7 +578,7 @@ Object {
 }
 `;
 
-exports[`#23 - babel (default) - function * namedFn (c) {return c * 3} 1`] = `
+exports[`#25 - babel (default) - function * namedFn (c) {return c * 3} 1`] = `
 Object {
   "args": Array [
     "c",
@@ -513,6 +587,7 @@ Object {
   "defaults": Object {
     "c": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -526,7 +601,7 @@ Object {
 }
 `;
 
-exports[`#24 - babel (default) - function * namedFn (...restArgs) {return 321} 1`] = `
+exports[`#26 - babel (default) - function * namedFn (...restArgs) {return 321} 1`] = `
 Object {
   "args": Array [
     "restArgs",
@@ -535,6 +610,7 @@ Object {
   "defaults": Object {
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -548,11 +624,12 @@ Object {
 }
 `;
 
-exports[`#25 - babel (default) - function * namedFn () {} 1`] = `
+exports[`#27 - babel (default) - function * namedFn () {} 1`] = `
 Object {
   "args": Array [],
   "body": "",
   "defaults": Object {},
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -566,7 +643,7 @@ Object {
 }
 `;
 
-exports[`#26 - babel (default) - function * namedFn(a = (true, false)) {} 1`] = `
+exports[`#28 - babel (default) - function * namedFn(a = (true, false)) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -575,6 +652,7 @@ Object {
   "defaults": Object {
     "a": "false",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -588,7 +666,7 @@ Object {
 }
 `;
 
-exports[`#27 - babel (default) - function * namedFn(a = (true, null)) {} 1`] = `
+exports[`#29 - babel (default) - function * namedFn(a = (true, null)) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -597,6 +675,7 @@ Object {
   "defaults": Object {
     "a": "null",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -610,7 +689,7 @@ Object {
 }
 `;
 
-exports[`#28 - babel (default) - function * namedFn(a = (true, "bar")) {} 1`] = `
+exports[`#30 - babel (default) - function * namedFn(a = (true, "bar")) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -619,6 +698,7 @@ Object {
   "defaults": Object {
     "a": "\\"bar\\"",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -632,7 +712,7 @@ Object {
 }
 `;
 
-exports[`#29 - babel (default) - function * namedFn(a, b = (i++, true)) {} 1`] = `
+exports[`#31 - babel (default) - function * namedFn(a, b = (i++, true)) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -643,6 +723,7 @@ Object {
     "a": undefined,
     "b": "true",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -656,7 +737,7 @@ Object {
 }
 `;
 
-exports[`#30 - babel (default) - function * namedFn(a = 1) {} 1`] = `
+exports[`#32 - babel (default) - function * namedFn(a = 1) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -665,6 +746,7 @@ Object {
   "defaults": Object {
     "a": "1",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -678,7 +760,33 @@ Object {
 }
 `;
 
-exports[`#31 - babel (default) - a = {foo: "ba)r", baz: 123}, cb, ...restArgs) => {return a * 3} 1`] = `
+exports[`#33 - babel (default) - function * namedFn({x, y}) {} 1`] = `
+Object {
+  "args": Array [
+    false,
+  ],
+  "body": "",
+  "defaults": Object {
+    "false": undefined,
+  },
+  "destructuredArgs": Array [
+    "x",
+    "y",
+  ],
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": true,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "false",
+  "value": "function * namedFn({x, y}) {}",
+}
+`;
+
+exports[`#34 - babel (default) - a = {foo: "ba)r", baz: 123}, cb, ...restArgs) => {return a * 3} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -691,6 +799,7 @@ Object {
     "cb": undefined,
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -704,7 +813,7 @@ Object {
 }
 `;
 
-exports[`#32 - babel (default) - b, callback, ...restArgs) => {callback(null, b + 3)} 1`] = `
+exports[`#35 - babel (default) - b, callback, ...restArgs) => {callback(null, b + 3)} 1`] = `
 Object {
   "args": Array [
     "b",
@@ -717,6 +826,7 @@ Object {
     "callback": undefined,
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -730,7 +840,7 @@ Object {
 }
 `;
 
-exports[`#33 - babel (default) - c) => {return c * 3} 1`] = `
+exports[`#36 - babel (default) - c) => {return c * 3} 1`] = `
 Object {
   "args": Array [
     "c",
@@ -739,6 +849,7 @@ Object {
   "defaults": Object {
     "c": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -752,7 +863,7 @@ Object {
 }
 `;
 
-exports[`#34 - babel (default) - ...restArgs) => {return 321} 1`] = `
+exports[`#37 - babel (default) - ...restArgs) => {return 321} 1`] = `
 Object {
   "args": Array [
     "restArgs",
@@ -761,6 +872,7 @@ Object {
   "defaults": Object {
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -774,11 +886,12 @@ Object {
 }
 `;
 
-exports[`#35 - babel (default) - ) => {} 1`] = `
+exports[`#38 - babel (default) - ) => {} 1`] = `
 Object {
   "args": Array [],
   "body": "",
   "defaults": Object {},
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -792,7 +905,7 @@ Object {
 }
 `;
 
-exports[`#36 - babel (default) - a = (true, false)) => {} 1`] = `
+exports[`#39 - babel (default) - a = (true, false)) => {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -801,6 +914,7 @@ Object {
   "defaults": Object {
     "a": "false",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -814,7 +928,7 @@ Object {
 }
 `;
 
-exports[`#37 - babel (default) - a = (true, null)) => {} 1`] = `
+exports[`#40 - babel (default) - a = (true, null)) => {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -823,6 +937,7 @@ Object {
   "defaults": Object {
     "a": "null",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -836,7 +951,7 @@ Object {
 }
 `;
 
-exports[`#38 - babel (default) - a = (true, "bar")) => {} 1`] = `
+exports[`#41 - babel (default) - a = (true, "bar")) => {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -845,6 +960,7 @@ Object {
   "defaults": Object {
     "a": "\\"bar\\"",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -858,7 +974,7 @@ Object {
 }
 `;
 
-exports[`#39 - babel (default) - a, b = (i++, true)) => {} 1`] = `
+exports[`#42 - babel (default) - a, b = (i++, true)) => {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -869,6 +985,7 @@ Object {
     "a": undefined,
     "b": "true",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -882,7 +999,7 @@ Object {
 }
 `;
 
-exports[`#40 - babel (default) - a = 1) => {} 1`] = `
+exports[`#43 - babel (default) - a = 1) => {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -891,6 +1008,7 @@ Object {
   "defaults": Object {
     "a": "1",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -904,7 +1022,7 @@ Object {
 }
 `;
 
-exports[`#41 - babel (default) - a) => a * 3 * a 1`] = `
+exports[`#44 - babel (default) - a) => a * 3 * a 1`] = `
 Object {
   "args": Array [
     "a",
@@ -913,6 +1031,7 @@ Object {
   "defaults": Object {
     "a": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -926,7 +1045,7 @@ Object {
 }
 `;
 
-exports[`#42 - babel (default) - d => d * 355 * d 1`] = `
+exports[`#45 - babel (default) - d => d * 355 * d 1`] = `
 Object {
   "args": Array [
     "d",
@@ -935,6 +1054,7 @@ Object {
   "defaults": Object {
     "d": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -948,7 +1068,7 @@ Object {
 }
 `;
 
-exports[`#43 - babel (default) - e => {return e + 5235 / e} 1`] = `
+exports[`#46 - babel (default) - e => {return e + 5235 / e} 1`] = `
 Object {
   "args": Array [
     "e",
@@ -957,6 +1077,7 @@ Object {
   "defaults": Object {
     "e": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -970,7 +1091,7 @@ Object {
 }
 `;
 
-exports[`#44 - babel (default) - a, b) => a + 3 + b 1`] = `
+exports[`#47 - babel (default) - a, b) => a + 3 + b 1`] = `
 Object {
   "args": Array [
     "a",
@@ -981,6 +1102,7 @@ Object {
     "a": undefined,
     "b": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -994,7 +1116,7 @@ Object {
 }
 `;
 
-exports[`#45 - babel (default) - x, y, ...restArgs) => console.log({ value: x * y } 1`] = `
+exports[`#48 - babel (default) - x, y, ...restArgs) => console.log({ value: x * y } 1`] = `
 Object {
   "args": Array [
     "x",
@@ -1007,6 +1129,7 @@ Object {
     "x": undefined,
     "y": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -1020,40 +1143,19 @@ Object {
 }
 `;
 
-exports[`#46 - babel (default) - async function (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
+exports[`#49 - babel (default) - x, y}) => {} 1`] = `
 Object {
   "args": Array [
-    "a",
-    "cb",
-    "restArgs",
+    false,
   ],
-  "body": "return a * 3",
+  "body": "",
   "defaults": Object {
-    "a": "{foo: \\"ba)r\\", baz: 123}",
-    "cb": undefined,
-    "restArgs": undefined,
+    "false": undefined,
   },
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a, cb, restArgs",
-  "value": "async function (a = {foo: \\"ba)r\\", baz: 123}, cb, ...restArgs) {return a * 3}",
-}
-`;
-
-exports[`#46 - babel (default) - x, y}) => {} 1`] = `
-Object {
-  "args": Array [
+  "destructuredArgs": Array [
     "x",
     "y",
   ],
-  "body": "",
-  "defaults": Object {},
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -1062,12 +1164,12 @@ Object {
   "isNamed": false,
   "isValid": true,
   "name": null,
-  "params": "x, y",
+  "params": "false",
   "value": "({x, y}) => {}",
 }
 `;
 
-exports[`#47 - babel (default) - async function (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
+exports[`#50 - babel (default) - async function (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -1080,6 +1182,7 @@ Object {
     "cb": undefined,
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": true,
@@ -1093,7 +1196,7 @@ Object {
 }
 `;
 
-exports[`#47 - babel (default) - async function (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
+exports[`#51 - babel (default) - async function (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
 Object {
   "args": Array [
     "b",
@@ -1106,6 +1209,7 @@ Object {
     "callback": undefined,
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": true,
@@ -1119,33 +1223,7 @@ Object {
 }
 `;
 
-exports[`#48 - babel (default) - async function (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
-Object {
-  "args": Array [
-    "b",
-    "callback",
-    "restArgs",
-  ],
-  "body": "callback(null, b + 3)",
-  "defaults": Object {
-    "b": undefined,
-    "callback": undefined,
-    "restArgs": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "b, callback, restArgs",
-  "value": "async function (b, callback, ...restArgs) {callback(null, b + 3)}",
-}
-`;
-
-exports[`#48 - babel (default) - async function (c) {return c * 3} 1`] = `
+exports[`#52 - babel (default) - async function (c) {return c * 3} 1`] = `
 Object {
   "args": Array [
     "c",
@@ -1154,6 +1232,7 @@ Object {
   "defaults": Object {
     "c": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": true,
@@ -1167,7 +1246,7 @@ Object {
 }
 `;
 
-exports[`#49 - babel (default) - async function (...restArgs) {return 321} 1`] = `
+exports[`#53 - babel (default) - async function (...restArgs) {return 321} 1`] = `
 Object {
   "args": Array [
     "restArgs",
@@ -1176,6 +1255,7 @@ Object {
   "defaults": Object {
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": true,
@@ -1189,33 +1269,12 @@ Object {
 }
 `;
 
-exports[`#49 - babel (default) - async function (c) {return c * 3} 1`] = `
-Object {
-  "args": Array [
-    "c",
-  ],
-  "body": "return c * 3",
-  "defaults": Object {
-    "c": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "c",
-  "value": "async function (c) {return c * 3}",
-}
-`;
-
-exports[`#50 - babel (default) - async function () {} 1`] = `
+exports[`#54 - babel (default) - async function () {} 1`] = `
 Object {
   "args": Array [],
   "body": "",
   "defaults": Object {},
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": true,
@@ -1229,47 +1288,7 @@ Object {
 }
 `;
 
-exports[`#50 - babel (default) - async function (...restArgs) {return 321} 1`] = `
-Object {
-  "args": Array [
-    "restArgs",
-  ],
-  "body": "return 321",
-  "defaults": Object {
-    "restArgs": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "restArgs",
-  "value": "async function (...restArgs) {return 321}",
-}
-`;
-
-exports[`#51 - babel (default) - async function () {} 1`] = `
-Object {
-  "args": Array [],
-  "body": "",
-  "defaults": Object {},
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "",
-  "value": "async function () {}",
-}
-`;
-
-exports[`#51 - babel (default) - async function (a = (true, false)) {} 1`] = `
+exports[`#55 - babel (default) - async function (a = (true, false)) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -1278,6 +1297,7 @@ Object {
   "defaults": Object {
     "a": "false",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": true,
@@ -1291,29 +1311,7 @@ Object {
 }
 `;
 
-exports[`#52 - babel (default) - async function (a = (true, false)) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "false",
-  },
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "async function (a = (true, false)) {}",
-}
-`;
-
-exports[`#52 - babel (default) - async function (a = (true, null)) {} 1`] = `
+exports[`#56 - babel (default) - async function (a = (true, null)) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -1322,6 +1320,7 @@ Object {
   "defaults": Object {
     "a": "null",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": true,
@@ -1335,7 +1334,7 @@ Object {
 }
 `;
 
-exports[`#53 - babel (default) - async function (a = (true, "bar")) {} 1`] = `
+exports[`#57 - babel (default) - async function (a = (true, "bar")) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -1344,6 +1343,7 @@ Object {
   "defaults": Object {
     "a": "\\"bar\\"",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": true,
@@ -1357,51 +1357,7 @@ Object {
 }
 `;
 
-exports[`#53 - babel (default) - async function (a = (true, null)) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "null",
-  },
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "async function (a = (true, null)) {}",
-}
-`;
-
-exports[`#54 - babel (default) - async function (a = (true, "bar")) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "\\"bar\\"",
-  },
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "async function (a = (true, \\"bar\\")) {}",
-}
-`;
-
-exports[`#54 - babel (default) - async function (a, b = (i++, true)) {} 1`] = `
+exports[`#58 - babel (default) - async function (a, b = (i++, true)) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -1412,6 +1368,7 @@ Object {
     "a": undefined,
     "b": "true",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": true,
@@ -1425,7 +1382,7 @@ Object {
 }
 `;
 
-exports[`#55 - babel (default) - async function (a = 1) {} 1`] = `
+exports[`#59 - babel (default) - async function (a = 1) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -1434,6 +1391,7 @@ Object {
   "defaults": Object {
     "a": "1",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": true,
@@ -1447,17 +1405,19 @@ Object {
 }
 `;
 
-exports[`#55 - babel (default) - async function (a, b = (i++, true)) {} 1`] = `
+exports[`#60 - babel (default) - async function ({x, y}) {} 1`] = `
 Object {
   "args": Array [
-    "a",
-    "b",
+    false,
   ],
   "body": "",
   "defaults": Object {
-    "a": undefined,
-    "b": "true",
+    "false": undefined,
   },
+  "destructuredArgs": Array [
+    "x",
+    "y",
+  ],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": true,
@@ -1466,34 +1426,12 @@ Object {
   "isNamed": false,
   "isValid": true,
   "name": null,
-  "params": "a, b",
-  "value": "async function (a, b = (i++, true)) {}",
+  "params": "false",
+  "value": "async function ({x, y}) {}",
 }
 `;
 
-exports[`#56 - babel (default) - async function (a = 1) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "1",
-  },
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "async function (a = 1) {}",
-}
-`;
-
-exports[`#56 - babel (default) - async function namedFn (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
+exports[`#61 - babel (default) - async function namedFn (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -1506,6 +1444,7 @@ Object {
     "cb": undefined,
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": true,
@@ -1519,33 +1458,7 @@ Object {
 }
 `;
 
-exports[`#57 - babel (default) - async function namedFn (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
-Object {
-  "args": Array [
-    "a",
-    "cb",
-    "restArgs",
-  ],
-  "body": "return a * 3",
-  "defaults": Object {
-    "a": "{foo: \\"ba)r\\", baz: 123}",
-    "cb": undefined,
-    "restArgs": undefined,
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "a, cb, restArgs",
-  "value": "async function namedFn (a = {foo: \\"ba)r\\", baz: 123}, cb, ...restArgs) {return a * 3}",
-}
-`;
-
-exports[`#57 - babel (default) - async function namedFn (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
+exports[`#62 - babel (default) - async function namedFn (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
 Object {
   "args": Array [
     "b",
@@ -1558,6 +1471,7 @@ Object {
     "callback": undefined,
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": true,
@@ -1571,33 +1485,7 @@ Object {
 }
 `;
 
-exports[`#58 - babel (default) - async function namedFn (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
-Object {
-  "args": Array [
-    "b",
-    "callback",
-    "restArgs",
-  ],
-  "body": "callback(null, b + 3)",
-  "defaults": Object {
-    "b": undefined,
-    "callback": undefined,
-    "restArgs": undefined,
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "b, callback, restArgs",
-  "value": "async function namedFn (b, callback, ...restArgs) {callback(null, b + 3)}",
-}
-`;
-
-exports[`#58 - babel (default) - async function namedFn (c) {return c * 3} 1`] = `
+exports[`#63 - babel (default) - async function namedFn (c) {return c * 3} 1`] = `
 Object {
   "args": Array [
     "c",
@@ -1606,6 +1494,7 @@ Object {
   "defaults": Object {
     "c": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": true,
@@ -1619,7 +1508,7 @@ Object {
 }
 `;
 
-exports[`#59 - babel (default) - async function namedFn (...restArgs) {return 321} 1`] = `
+exports[`#64 - babel (default) - async function namedFn (...restArgs) {return 321} 1`] = `
 Object {
   "args": Array [
     "restArgs",
@@ -1628,6 +1517,7 @@ Object {
   "defaults": Object {
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": true,
@@ -1641,33 +1531,12 @@ Object {
 }
 `;
 
-exports[`#59 - babel (default) - async function namedFn (c) {return c * 3} 1`] = `
-Object {
-  "args": Array [
-    "c",
-  ],
-  "body": "return c * 3",
-  "defaults": Object {
-    "c": undefined,
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "c",
-  "value": "async function namedFn (c) {return c * 3}",
-}
-`;
-
-exports[`#60 - babel (default) - async function namedFn () {} 1`] = `
+exports[`#65 - babel (default) - async function namedFn () {} 1`] = `
 Object {
   "args": Array [],
   "body": "",
   "defaults": Object {},
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": true,
@@ -1681,47 +1550,7 @@ Object {
 }
 `;
 
-exports[`#60 - babel (default) - async function namedFn (...restArgs) {return 321} 1`] = `
-Object {
-  "args": Array [
-    "restArgs",
-  ],
-  "body": "return 321",
-  "defaults": Object {
-    "restArgs": undefined,
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "restArgs",
-  "value": "async function namedFn (...restArgs) {return 321}",
-}
-`;
-
-exports[`#61 - babel (default) - async function namedFn () {} 1`] = `
-Object {
-  "args": Array [],
-  "body": "",
-  "defaults": Object {},
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "",
-  "value": "async function namedFn () {}",
-}
-`;
-
-exports[`#61 - babel (default) - async function namedFn(a = (true, false)) {} 1`] = `
+exports[`#66 - babel (default) - async function namedFn(a = (true, false)) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -1730,6 +1559,7 @@ Object {
   "defaults": Object {
     "a": "false",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": true,
@@ -1743,29 +1573,7 @@ Object {
 }
 `;
 
-exports[`#62 - babel (default) - async function namedFn(a = (true, false)) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "false",
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "a",
-  "value": "async function namedFn(a = (true, false)) {}",
-}
-`;
-
-exports[`#62 - babel (default) - async function namedFn(a = (true, null)) {} 1`] = `
+exports[`#67 - babel (default) - async function namedFn(a = (true, null)) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -1774,6 +1582,7 @@ Object {
   "defaults": Object {
     "a": "null",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": true,
@@ -1787,7 +1596,7 @@ Object {
 }
 `;
 
-exports[`#63 - babel (default) - async function namedFn(a = (true, "bar")) {} 1`] = `
+exports[`#68 - babel (default) - async function namedFn(a = (true, "bar")) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -1796,6 +1605,7 @@ Object {
   "defaults": Object {
     "a": "\\"bar\\"",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": true,
@@ -1809,51 +1619,7 @@ Object {
 }
 `;
 
-exports[`#63 - babel (default) - async function namedFn(a = (true, null)) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "null",
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "a",
-  "value": "async function namedFn(a = (true, null)) {}",
-}
-`;
-
-exports[`#64 - babel (default) - async function namedFn(a = (true, "bar")) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "\\"bar\\"",
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "a",
-  "value": "async function namedFn(a = (true, \\"bar\\")) {}",
-}
-`;
-
-exports[`#64 - babel (default) - async function namedFn(a, b = (i++, true)) {} 1`] = `
+exports[`#69 - babel (default) - async function namedFn(a, b = (i++, true)) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -1864,6 +1630,7 @@ Object {
     "a": undefined,
     "b": "true",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": true,
@@ -1877,7 +1644,7 @@ Object {
 }
 `;
 
-exports[`#65 - babel (default) - async function namedFn(a = 1) {} 1`] = `
+exports[`#70 - babel (default) - async function namedFn(a = 1) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -1886,6 +1653,7 @@ Object {
   "defaults": Object {
     "a": "1",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": true,
@@ -1899,17 +1667,19 @@ Object {
 }
 `;
 
-exports[`#65 - babel (default) - async function namedFn(a, b = (i++, true)) {} 1`] = `
+exports[`#71 - babel (default) - async function namedFn({x, y}) {} 1`] = `
 Object {
   "args": Array [
-    "a",
-    "b",
+    false,
   ],
   "body": "",
   "defaults": Object {
-    "a": undefined,
-    "b": "true",
+    "false": undefined,
   },
+  "destructuredArgs": Array [
+    "x",
+    "y",
+  ],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": true,
@@ -1918,12 +1688,12 @@ Object {
   "isNamed": true,
   "isValid": true,
   "name": "namedFn",
-  "params": "a, b",
-  "value": "async function namedFn(a, b = (i++, true)) {}",
+  "params": "false",
+  "value": "async function namedFn({x, y}) {}",
 }
 `;
 
-exports[`#66 - babel (default) - async (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) => {return a * 3} 1`] = `
+exports[`#72 - babel (default) - async (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) => {return a * 3} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -1936,6 +1706,7 @@ Object {
     "cb": undefined,
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -1949,55 +1720,7 @@ Object {
 }
 `;
 
-exports[`#66 - babel (default) - async function namedFn(a = 1) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "1",
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "a",
-  "value": "async function namedFn(a = 1) {}",
-}
-`;
-
-exports[`#67 - babel (default) - async (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) => {return a * 3} 1`] = `
-Object {
-  "args": Array [
-    "a",
-    "cb",
-    "restArgs",
-  ],
-  "body": "return a * 3",
-  "defaults": Object {
-    "a": "{foo: \\"ba)r\\", baz: 123}",
-    "cb": undefined,
-    "restArgs": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a, cb, restArgs",
-  "value": "async (a = {foo: \\"ba)r\\", baz: 123}, cb, ...restArgs) => {return a * 3}",
-}
-`;
-
-exports[`#67 - babel (default) - async (b, callback, ...restArgs) => {callback(null, b + 3)} 1`] = `
+exports[`#73 - babel (default) - async (b, callback, ...restArgs) => {callback(null, b + 3)} 1`] = `
 Object {
   "args": Array [
     "b",
@@ -2010,6 +1733,7 @@ Object {
     "callback": undefined,
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -2023,33 +1747,7 @@ Object {
 }
 `;
 
-exports[`#68 - babel (default) - async (b, callback, ...restArgs) => {callback(null, b + 3)} 1`] = `
-Object {
-  "args": Array [
-    "b",
-    "callback",
-    "restArgs",
-  ],
-  "body": "callback(null, b + 3)",
-  "defaults": Object {
-    "b": undefined,
-    "callback": undefined,
-    "restArgs": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "b, callback, restArgs",
-  "value": "async (b, callback, ...restArgs) => {callback(null, b + 3)}",
-}
-`;
-
-exports[`#68 - babel (default) - async (c) => {return c * 3} 1`] = `
+exports[`#74 - babel (default) - async (c) => {return c * 3} 1`] = `
 Object {
   "args": Array [
     "c",
@@ -2058,6 +1756,7 @@ Object {
   "defaults": Object {
     "c": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -2071,7 +1770,7 @@ Object {
 }
 `;
 
-exports[`#69 - babel (default) - async (...restArgs) => {return 321} 1`] = `
+exports[`#75 - babel (default) - async (...restArgs) => {return 321} 1`] = `
 Object {
   "args": Array [
     "restArgs",
@@ -2080,6 +1779,7 @@ Object {
   "defaults": Object {
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -2093,33 +1793,12 @@ Object {
 }
 `;
 
-exports[`#69 - babel (default) - async (c) => {return c * 3} 1`] = `
-Object {
-  "args": Array [
-    "c",
-  ],
-  "body": "return c * 3",
-  "defaults": Object {
-    "c": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "c",
-  "value": "async (c) => {return c * 3}",
-}
-`;
-
-exports[`#70 - babel (default) - async () => {} 1`] = `
+exports[`#76 - babel (default) - async () => {} 1`] = `
 Object {
   "args": Array [],
   "body": "",
   "defaults": Object {},
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -2133,47 +1812,7 @@ Object {
 }
 `;
 
-exports[`#70 - babel (default) - async (...restArgs) => {return 321} 1`] = `
-Object {
-  "args": Array [
-    "restArgs",
-  ],
-  "body": "return 321",
-  "defaults": Object {
-    "restArgs": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "restArgs",
-  "value": "async (...restArgs) => {return 321}",
-}
-`;
-
-exports[`#71 - babel (default) - async () => {} 1`] = `
-Object {
-  "args": Array [],
-  "body": "",
-  "defaults": Object {},
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "",
-  "value": "async () => {}",
-}
-`;
-
-exports[`#71 - babel (default) - async (a = (true, false)) => {} 1`] = `
+exports[`#77 - babel (default) - async (a = (true, false)) => {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -2182,6 +1821,7 @@ Object {
   "defaults": Object {
     "a": "false",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -2195,29 +1835,7 @@ Object {
 }
 `;
 
-exports[`#72 - babel (default) - async (a = (true, false)) => {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "false",
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "async (a = (true, false)) => {}",
-}
-`;
-
-exports[`#72 - babel (default) - async (a = (true, null)) => {} 1`] = `
+exports[`#78 - babel (default) - async (a = (true, null)) => {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -2226,6 +1844,7 @@ Object {
   "defaults": Object {
     "a": "null",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -2239,7 +1858,7 @@ Object {
 }
 `;
 
-exports[`#73 - babel (default) - async (a = (true, "bar")) => {} 1`] = `
+exports[`#79 - babel (default) - async (a = (true, "bar")) => {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -2248,6 +1867,7 @@ Object {
   "defaults": Object {
     "a": "\\"bar\\"",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -2261,51 +1881,7 @@ Object {
 }
 `;
 
-exports[`#73 - babel (default) - async (a = (true, null)) => {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "null",
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "async (a = (true, null)) => {}",
-}
-`;
-
-exports[`#74 - babel (default) - async (a = (true, "bar")) => {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "\\"bar\\"",
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "async (a = (true, \\"bar\\")) => {}",
-}
-`;
-
-exports[`#74 - babel (default) - async (a, b = (i++, true)) => {} 1`] = `
+exports[`#80 - babel (default) - async (a, b = (i++, true)) => {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -2316,6 +1892,7 @@ Object {
     "a": undefined,
     "b": "true",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -2329,7 +1906,7 @@ Object {
 }
 `;
 
-exports[`#75 - babel (default) - async (a = 1) => {} 1`] = `
+exports[`#81 - babel (default) - async (a = 1) => {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -2338,6 +1915,7 @@ Object {
   "defaults": Object {
     "a": "1",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -2351,53 +1929,7 @@ Object {
 }
 `;
 
-exports[`#75 - babel (default) - async (a, b = (i++, true)) => {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-    "b",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": undefined,
-    "b": "true",
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a, b",
-  "value": "async (a, b = (i++, true)) => {}",
-}
-`;
-
-exports[`#76 - babel (default) - async (a = 1) => {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "1",
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "async (a = 1) => {}",
-}
-`;
-
-exports[`#76 - babel (default) - async (a) => a * 3 * a 1`] = `
+exports[`#82 - babel (default) - async (a) => a * 3 * a 1`] = `
 Object {
   "args": Array [
     "a",
@@ -2406,6 +1938,7 @@ Object {
   "defaults": Object {
     "a": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -2419,29 +1952,7 @@ Object {
 }
 `;
 
-exports[`#77 - babel (default) - async (a) => a * 3 * a 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "a * 3 * a",
-  "defaults": Object {
-    "a": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "async (a) => a * 3 * a",
-}
-`;
-
-exports[`#77 - babel (default) - async d => d * 355 * d 1`] = `
+exports[`#83 - babel (default) - async d => d * 355 * d 1`] = `
 Object {
   "args": Array [
     "d",
@@ -2450,6 +1961,7 @@ Object {
   "defaults": Object {
     "d": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -2463,29 +1975,7 @@ Object {
 }
 `;
 
-exports[`#78 - babel (default) - async d => d * 355 * d 1`] = `
-Object {
-  "args": Array [
-    "d",
-  ],
-  "body": "d * 355 * d",
-  "defaults": Object {
-    "d": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "d",
-  "value": "async d => d * 355 * d",
-}
-`;
-
-exports[`#78 - babel (default) - async e => {return e + 5235 / e} 1`] = `
+exports[`#84 - babel (default) - async e => {return e + 5235 / e} 1`] = `
 Object {
   "args": Array [
     "e",
@@ -2494,6 +1984,7 @@ Object {
   "defaults": Object {
     "e": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -2507,7 +1998,7 @@ Object {
 }
 `;
 
-exports[`#79 - babel (default) - async (a, b) => a + 3 + b 1`] = `
+exports[`#85 - babel (default) - async (a, b) => a + 3 + b 1`] = `
 Object {
   "args": Array [
     "a",
@@ -2518,6 +2009,7 @@ Object {
     "a": undefined,
     "b": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -2531,53 +2023,7 @@ Object {
 }
 `;
 
-exports[`#79 - babel (default) - async e => {return e + 5235 / e} 1`] = `
-Object {
-  "args": Array [
-    "e",
-  ],
-  "body": "return e + 5235 / e",
-  "defaults": Object {
-    "e": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "e",
-  "value": "async e => {return e + 5235 / e}",
-}
-`;
-
-exports[`#80 - babel (default) - async (a, b) => a + 3 + b 1`] = `
-Object {
-  "args": Array [
-    "a",
-    "b",
-  ],
-  "body": "a + 3 + b",
-  "defaults": Object {
-    "a": undefined,
-    "b": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a, b",
-  "value": "async (a, b) => a + 3 + b",
-}
-`;
-
-exports[`#80 - babel (default) - async (x, y, ...restArgs) => console.log({ value: x * y } 1`] = `
+exports[`#86 - babel (default) - async (x, y, ...restArgs) => console.log({ value: x * y } 1`] = `
 Object {
   "args": Array [
     "x",
@@ -2590,6 +2036,7 @@ Object {
     "x": undefined,
     "y": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -2603,58 +2050,19 @@ Object {
 }
 `;
 
-exports[`#81 - babel (default) - async (x, y, ...restArgs) => console.log({ value: x * y } 1`] = `
+exports[`#87 - babel (default) - async ({x, y}) => {} 1`] = `
 Object {
   "args": Array [
-    "x",
-    "y",
-    "restArgs",
+    false,
   ],
-  "body": "console.log({ value: x * y })",
+  "body": "",
   "defaults": Object {
-    "restArgs": undefined,
-    "x": undefined,
-    "y": undefined,
+    "false": undefined,
   },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "x, y, restArgs",
-  "value": "async (x, y, ...restArgs) => console.log({ value: x * y })",
-}
-`;
-
-exports[`#81 - babel (default) - should return object with default values when invalid 1`] = `
-Object {
-  "args": Array [],
-  "body": "",
-  "defaults": Object {},
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": false,
-  "name": null,
-  "params": "",
-  "value": "",
-}
-`;
-
-exports[`#82 - babel (default) - async ({x, y}) => {} 1`] = `
-Object {
-  "args": Array [
+  "destructuredArgs": Array [
     "x",
     "y",
   ],
-  "body": "",
-  "defaults": Object {},
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -2663,12 +2071,12 @@ Object {
   "isNamed": false,
   "isValid": true,
   "name": null,
-  "params": "x, y",
+  "params": "false",
   "value": "async ({x, y}) => {}",
 }
 `;
 
-exports[`#82 - babel (default) - should have '.isValid' and few '.is*'' hidden properties 1`] = `
+exports[`#88 - babel (default) - should return object with default values when invalid 1`] = `
 Object {
   "args": Array [],
   "body": "",
@@ -2686,7 +2094,7 @@ Object {
 }
 `;
 
-exports[`#83 - babel (default) - should return object with default values when invalid 1`] = `
+exports[`#89 - babel (default) - should have '.isValid' and few '.is*'' hidden properties 1`] = `
 Object {
   "args": Array [],
   "body": "",
@@ -2704,25 +2112,7 @@ Object {
 }
 `;
 
-exports[`#84 - babel (default) - should have '.isValid' and few '.is*'' hidden properties 1`] = `
-Object {
-  "args": Array [],
-  "body": "",
-  "defaults": Object {},
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": false,
-  "name": null,
-  "params": "",
-  "value": "",
-}
-`;
-
-exports[`#87 - babel (default) - should work for object methods 1`] = `
+exports[`#94 - babel (default) - should work for object methods 1`] = `
 Object {
   "args": Array [
     "a",
@@ -2737,6 +2127,7 @@ Object {
     "b": undefined,
     "c": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -2752,7 +2143,7 @@ Object {
 }
 `;
 
-exports[`#87 - babel (default) - should work for object methods 2`] = `
+exports[`#94 - babel (default) - should work for object methods 2`] = `
 Object {
   "args": Array [
     "a",
@@ -2763,6 +2154,7 @@ Object {
   "defaults": Object {
     "a": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -2778,7 +2170,7 @@ Object {
 }
 `;
 
-exports[`#87 - babel (default) - should work for object methods 3`] = `
+exports[`#94 - babel (default) - should work for object methods 3`] = `
 Object {
   "args": Array [
     "a",
@@ -2789,6 +2181,7 @@ Object {
   "defaults": Object {
     "a": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -2804,7 +2197,7 @@ Object {
 }
 `;
 
-exports[`#87 - babel (default) - should work for object methods 4`] = `
+exports[`#94 - babel (default) - should work for object methods 4`] = `
 Object {
   "args": Array [
     "a",
@@ -2817,6 +2210,7 @@ Object {
     "cb": undefined,
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -2830,115 +2224,7 @@ Object {
 }
 `;
 
-exports[`#89 - babel (default) - should work for object methods 1`] = `
-Object {
-  "args": Array [
-    "a",
-    "b",
-    "c",
-  ],
-  "body": "
-        return 123;
-      ",
-  "defaults": Object {
-    "a": undefined,
-    "b": undefined,
-    "c": undefined,
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "foo",
-  "params": "a, b, c",
-  "value": "{ foo(a, b, c) {
-        return 123;
-      } }",
-}
-`;
-
-exports[`#89 - babel (default) - should work for object methods 2`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "
-        return () => a;
-      ",
-  "defaults": Object {
-    "a": undefined,
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "bar",
-  "params": "a",
-  "value": "{ bar(a) {
-        return () => a;
-      } }",
-}
-`;
-
-exports[`#89 - babel (default) - should work for object methods 3`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "
-        return yield a * 321;
-      ",
-  "defaults": Object {
-    "a": undefined,
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": true,
-  "isNamed": true,
-  "isValid": true,
-  "name": "gen",
-  "params": "a",
-  "value": "{ *gen(a) {
-        return yield a * 321;
-      } }",
-}
-`;
-
-exports[`#89 - babel (default) - should work for object methods 4`] = `
-Object {
-  "args": Array [
-    "a",
-    "cb",
-    "restArgs",
-  ],
-  "body": " return a * 3 ",
-  "defaults": Object {
-    "a": "{foo: 'ba)r', baz: 123}",
-    "cb": undefined,
-    "restArgs": undefined,
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "a, cb, restArgs",
-  "value": "{ namedFn (a = {foo: 'ba)r', baz: 123}, cb, ...restArgs) { return a * 3 } }",
-}
-`;
-
-exports[`#91 - options.parse + ecmaVersion: 2019 - function (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
+exports[`#98 - options.parse + ecmaVersion: 2019 - function (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -2951,6 +2237,7 @@ Object {
     "cb": undefined,
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": false,
@@ -2964,7 +2251,7 @@ Object {
 }
 `;
 
-exports[`#92 - options.parse + ecmaVersion: 2019 - function (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
+exports[`#99 - options.parse + ecmaVersion: 2019 - function (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
 Object {
   "args": Array [
     "b",
@@ -2977,6 +2264,7 @@ Object {
     "callback": undefined,
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": false,
@@ -2990,33 +2278,7 @@ Object {
 }
 `;
 
-exports[`#93 - options.parse + ecmaVersion: 2019 - function (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
-Object {
-  "args": Array [
-    "a",
-    "cb",
-    "restArgs",
-  ],
-  "body": "return a * 3",
-  "defaults": Object {
-    "a": "{foo: \\"ba)r\\", baz: 123}",
-    "cb": undefined,
-    "restArgs": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a, cb, restArgs",
-  "value": "(function (a = {foo: \\"ba)r\\", baz: 123}, cb, ...restArgs) {return a * 3})",
-}
-`;
-
-exports[`#93 - options.parse + ecmaVersion: 2019 - function (c) {return c * 3} 1`] = `
+exports[`#100 - options.parse + ecmaVersion: 2019 - function (c) {return c * 3} 1`] = `
 Object {
   "args": Array [
     "c",
@@ -3025,6 +2287,7 @@ Object {
   "defaults": Object {
     "c": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": false,
@@ -3038,7 +2301,7 @@ Object {
 }
 `;
 
-exports[`#94 - options.parse + ecmaVersion: 2019 - function (...restArgs) {return 321} 1`] = `
+exports[`#101 - options.parse + ecmaVersion: 2019 - function (...restArgs) {return 321} 1`] = `
 Object {
   "args": Array [
     "restArgs",
@@ -3047,6 +2310,7 @@ Object {
   "defaults": Object {
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": false,
@@ -3060,37 +2324,12 @@ Object {
 }
 `;
 
-exports[`#94 - options.parse + ecmaVersion: 2019 - function (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
-Object {
-  "args": Array [
-    "b",
-    "callback",
-    "restArgs",
-  ],
-  "body": "callback(null, b + 3)",
-  "defaults": Object {
-    "b": undefined,
-    "callback": undefined,
-    "restArgs": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "b, callback, restArgs",
-  "value": "(function (b, callback, ...restArgs) {callback(null, b + 3)})",
-}
-`;
-
-exports[`#95 - options.parse + ecmaVersion: 2019 - function () {} 1`] = `
+exports[`#102 - options.parse + ecmaVersion: 2019 - function () {} 1`] = `
 Object {
   "args": Array [],
   "body": "",
   "defaults": Object {},
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": false,
@@ -3104,51 +2343,7 @@ Object {
 }
 `;
 
-exports[`#95 - options.parse + ecmaVersion: 2019 - function (c) {return c * 3} 1`] = `
-Object {
-  "args": Array [
-    "c",
-  ],
-  "body": "return c * 3",
-  "defaults": Object {
-    "c": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "c",
-  "value": "(function (c) {return c * 3})",
-}
-`;
-
-exports[`#96 - options.parse + ecmaVersion: 2019 - function (...restArgs) {return 321} 1`] = `
-Object {
-  "args": Array [
-    "restArgs",
-  ],
-  "body": "return 321",
-  "defaults": Object {
-    "restArgs": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "restArgs",
-  "value": "(function (...restArgs) {return 321})",
-}
-`;
-
-exports[`#96 - options.parse + ecmaVersion: 2019 - function (a = (true, false)) {} 1`] = `
+exports[`#103 - options.parse + ecmaVersion: 2019 - function (a = (true, false)) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -3157,6 +2352,7 @@ Object {
   "defaults": Object {
     "a": "false",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": false,
@@ -3170,25 +2366,7 @@ Object {
 }
 `;
 
-exports[`#97 - options.parse + ecmaVersion: 2019 - function () {} 1`] = `
-Object {
-  "args": Array [],
-  "body": "",
-  "defaults": Object {},
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "",
-  "value": "(function () {})",
-}
-`;
-
-exports[`#97 - options.parse + ecmaVersion: 2019 - function (a = (true, null)) {} 1`] = `
+exports[`#104 - options.parse + ecmaVersion: 2019 - function (a = (true, null)) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -3197,6 +2375,7 @@ Object {
   "defaults": Object {
     "a": "null",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": false,
@@ -3210,7 +2389,7 @@ Object {
 }
 `;
 
-exports[`#98 - options.parse + ecmaVersion: 2019 - function (a = (true, "bar")) {} 1`] = `
+exports[`#105 - options.parse + ecmaVersion: 2019 - function (a = (true, "bar")) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -3219,6 +2398,7 @@ Object {
   "defaults": Object {
     "a": "\\"bar\\"",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": false,
@@ -3232,51 +2412,7 @@ Object {
 }
 `;
 
-exports[`#98 - options.parse + ecmaVersion: 2019 - function (a = (true, false)) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "false",
-  },
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "(function (a = (true, false)) {})",
-}
-`;
-
-exports[`#99 - options.parse + ecmaVersion: 2019 - function (a = (true, null)) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "null",
-  },
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "(function (a = (true, null)) {})",
-}
-`;
-
-exports[`#99 - options.parse + ecmaVersion: 2019 - function (a, b = (i++, true)) {} 1`] = `
+exports[`#106 - options.parse + ecmaVersion: 2019 - function (a, b = (i++, true)) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -3287,6 +2423,7 @@ Object {
     "a": undefined,
     "b": "true",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": false,
@@ -3300,29 +2437,7 @@ Object {
 }
 `;
 
-exports[`#100 - options.parse + ecmaVersion: 2019 - function (a = (true, "bar")) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "\\"bar\\"",
-  },
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "(function (a = (true, \\"bar\\")) {})",
-}
-`;
-
-exports[`#100 - options.parse + ecmaVersion: 2019 - function (a = 1) {} 1`] = `
+exports[`#107 - options.parse + ecmaVersion: 2019 - function (a = 1) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -3331,6 +2446,7 @@ Object {
   "defaults": Object {
     "a": "1",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": false,
@@ -3344,17 +2460,19 @@ Object {
 }
 `;
 
-exports[`#101 - options.parse + ecmaVersion: 2019 - function (a, b = (i++, true)) {} 1`] = `
+exports[`#108 - options.parse + ecmaVersion: 2019 - function ({x, y}) {} 1`] = `
 Object {
   "args": Array [
-    "a",
-    "b",
+    false,
   ],
   "body": "",
   "defaults": Object {
-    "a": undefined,
-    "b": "true",
+    "false": undefined,
   },
+  "destructuredArgs": Array [
+    "x",
+    "y",
+  ],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": false,
@@ -3363,12 +2481,12 @@ Object {
   "isNamed": false,
   "isValid": true,
   "name": null,
-  "params": "a, b",
-  "value": "(function (a, b = (i++, true)) {})",
+  "params": "false",
+  "value": "(function ({x, y}) {})",
 }
 `;
 
-exports[`#101 - options.parse + ecmaVersion: 2019 - function namedFn (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
+exports[`#109 - options.parse + ecmaVersion: 2019 - function namedFn (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -3381,6 +2499,7 @@ Object {
     "cb": undefined,
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -3394,29 +2513,7 @@ Object {
 }
 `;
 
-exports[`#102 - options.parse + ecmaVersion: 2019 - function (a = 1) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "1",
-  },
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "(function (a = 1) {})",
-}
-`;
-
-exports[`#102 - options.parse + ecmaVersion: 2019 - function namedFn (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
+exports[`#110 - options.parse + ecmaVersion: 2019 - function namedFn (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
 Object {
   "args": Array [
     "b",
@@ -3429,6 +2526,7 @@ Object {
     "callback": undefined,
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -3442,33 +2540,7 @@ Object {
 }
 `;
 
-exports[`#103 - options.parse + ecmaVersion: 2019 - function namedFn (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
-Object {
-  "args": Array [
-    "a",
-    "cb",
-    "restArgs",
-  ],
-  "body": "return a * 3",
-  "defaults": Object {
-    "a": "{foo: \\"ba)r\\", baz: 123}",
-    "cb": undefined,
-    "restArgs": undefined,
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "a, cb, restArgs",
-  "value": "(function namedFn (a = {foo: \\"ba)r\\", baz: 123}, cb, ...restArgs) {return a * 3})",
-}
-`;
-
-exports[`#103 - options.parse + ecmaVersion: 2019 - function namedFn (c) {return c * 3} 1`] = `
+exports[`#111 - options.parse + ecmaVersion: 2019 - function namedFn (c) {return c * 3} 1`] = `
 Object {
   "args": Array [
     "c",
@@ -3477,6 +2549,7 @@ Object {
   "defaults": Object {
     "c": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -3490,7 +2563,7 @@ Object {
 }
 `;
 
-exports[`#104 - options.parse + ecmaVersion: 2019 - function namedFn (...restArgs) {return 321} 1`] = `
+exports[`#112 - options.parse + ecmaVersion: 2019 - function namedFn (...restArgs) {return 321} 1`] = `
 Object {
   "args": Array [
     "restArgs",
@@ -3499,6 +2572,7 @@ Object {
   "defaults": Object {
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -3512,37 +2586,12 @@ Object {
 }
 `;
 
-exports[`#104 - options.parse + ecmaVersion: 2019 - function namedFn (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
-Object {
-  "args": Array [
-    "b",
-    "callback",
-    "restArgs",
-  ],
-  "body": "callback(null, b + 3)",
-  "defaults": Object {
-    "b": undefined,
-    "callback": undefined,
-    "restArgs": undefined,
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "b, callback, restArgs",
-  "value": "(function namedFn (b, callback, ...restArgs) {callback(null, b + 3)})",
-}
-`;
-
-exports[`#105 - options.parse + ecmaVersion: 2019 - function namedFn () {} 1`] = `
+exports[`#113 - options.parse + ecmaVersion: 2019 - function namedFn () {} 1`] = `
 Object {
   "args": Array [],
   "body": "",
   "defaults": Object {},
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -3556,51 +2605,7 @@ Object {
 }
 `;
 
-exports[`#105 - options.parse + ecmaVersion: 2019 - function namedFn (c) {return c * 3} 1`] = `
-Object {
-  "args": Array [
-    "c",
-  ],
-  "body": "return c * 3",
-  "defaults": Object {
-    "c": undefined,
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "c",
-  "value": "(function namedFn (c) {return c * 3})",
-}
-`;
-
-exports[`#106 - options.parse + ecmaVersion: 2019 - function namedFn (...restArgs) {return 321} 1`] = `
-Object {
-  "args": Array [
-    "restArgs",
-  ],
-  "body": "return 321",
-  "defaults": Object {
-    "restArgs": undefined,
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "restArgs",
-  "value": "(function namedFn (...restArgs) {return 321})",
-}
-`;
-
-exports[`#106 - options.parse + ecmaVersion: 2019 - function namedFn(a = (true, false)) {} 1`] = `
+exports[`#114 - options.parse + ecmaVersion: 2019 - function namedFn(a = (true, false)) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -3609,6 +2614,7 @@ Object {
   "defaults": Object {
     "a": "false",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -3622,25 +2628,7 @@ Object {
 }
 `;
 
-exports[`#107 - options.parse + ecmaVersion: 2019 - function namedFn () {} 1`] = `
-Object {
-  "args": Array [],
-  "body": "",
-  "defaults": Object {},
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "",
-  "value": "(function namedFn () {})",
-}
-`;
-
-exports[`#107 - options.parse + ecmaVersion: 2019 - function namedFn(a = (true, null)) {} 1`] = `
+exports[`#115 - options.parse + ecmaVersion: 2019 - function namedFn(a = (true, null)) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -3649,6 +2637,7 @@ Object {
   "defaults": Object {
     "a": "null",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -3662,7 +2651,7 @@ Object {
 }
 `;
 
-exports[`#108 - options.parse + ecmaVersion: 2019 - function namedFn(a = (true, "bar")) {} 1`] = `
+exports[`#116 - options.parse + ecmaVersion: 2019 - function namedFn(a = (true, "bar")) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -3671,6 +2660,7 @@ Object {
   "defaults": Object {
     "a": "\\"bar\\"",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -3684,51 +2674,7 @@ Object {
 }
 `;
 
-exports[`#108 - options.parse + ecmaVersion: 2019 - function namedFn(a = (true, false)) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "false",
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "a",
-  "value": "(function namedFn(a = (true, false)) {})",
-}
-`;
-
-exports[`#109 - options.parse + ecmaVersion: 2019 - function namedFn(a = (true, null)) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "null",
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "a",
-  "value": "(function namedFn(a = (true, null)) {})",
-}
-`;
-
-exports[`#109 - options.parse + ecmaVersion: 2019 - function namedFn(a, b = (i++, true)) {} 1`] = `
+exports[`#117 - options.parse + ecmaVersion: 2019 - function namedFn(a, b = (i++, true)) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -3739,6 +2685,7 @@ Object {
     "a": undefined,
     "b": "true",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -3752,29 +2699,7 @@ Object {
 }
 `;
 
-exports[`#110 - options.parse + ecmaVersion: 2019 - function namedFn(a = (true, "bar")) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "\\"bar\\"",
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "a",
-  "value": "(function namedFn(a = (true, \\"bar\\")) {})",
-}
-`;
-
-exports[`#110 - options.parse + ecmaVersion: 2019 - function namedFn(a = 1) {} 1`] = `
+exports[`#118 - options.parse + ecmaVersion: 2019 - function namedFn(a = 1) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -3783,6 +2708,7 @@ Object {
   "defaults": Object {
     "a": "1",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -3796,7 +2722,33 @@ Object {
 }
 `;
 
-exports[`#111 - options.parse + ecmaVersion: 2019 - function * namedFn (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
+exports[`#119 - options.parse + ecmaVersion: 2019 - function namedFn({x, y}) {} 1`] = `
+Object {
+  "args": Array [
+    false,
+  ],
+  "body": "",
+  "defaults": Object {
+    "false": undefined,
+  },
+  "destructuredArgs": Array [
+    "x",
+    "y",
+  ],
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "false",
+  "value": "(function namedFn({x, y}) {})",
+}
+`;
+
+exports[`#120 - options.parse + ecmaVersion: 2019 - function * namedFn (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -3809,6 +2761,7 @@ Object {
     "cb": undefined,
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -3822,31 +2775,7 @@ Object {
 }
 `;
 
-exports[`#111 - options.parse + ecmaVersion: 2019 - function namedFn(a, b = (i++, true)) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-    "b",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": undefined,
-    "b": "true",
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "a, b",
-  "value": "(function namedFn(a, b = (i++, true)) {})",
-}
-`;
-
-exports[`#112 - options.parse + ecmaVersion: 2019 - function * namedFn (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
+exports[`#121 - options.parse + ecmaVersion: 2019 - function * namedFn (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
 Object {
   "args": Array [
     "b",
@@ -3859,6 +2788,7 @@ Object {
     "callback": undefined,
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -3872,55 +2802,7 @@ Object {
 }
 `;
 
-exports[`#112 - options.parse + ecmaVersion: 2019 - function namedFn(a = 1) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "1",
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "a",
-  "value": "(function namedFn(a = 1) {})",
-}
-`;
-
-exports[`#113 - options.parse + ecmaVersion: 2019 - function * namedFn (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
-Object {
-  "args": Array [
-    "a",
-    "cb",
-    "restArgs",
-  ],
-  "body": "return a * 3",
-  "defaults": Object {
-    "a": "{foo: \\"ba)r\\", baz: 123}",
-    "cb": undefined,
-    "restArgs": undefined,
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": true,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "a, cb, restArgs",
-  "value": "(function * namedFn (a = {foo: \\"ba)r\\", baz: 123}, cb, ...restArgs) {return a * 3})",
-}
-`;
-
-exports[`#113 - options.parse + ecmaVersion: 2019 - function * namedFn (c) {return c * 3} 1`] = `
+exports[`#122 - options.parse + ecmaVersion: 2019 - function * namedFn (c) {return c * 3} 1`] = `
 Object {
   "args": Array [
     "c",
@@ -3929,6 +2811,7 @@ Object {
   "defaults": Object {
     "c": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -3942,7 +2825,7 @@ Object {
 }
 `;
 
-exports[`#114 - options.parse + ecmaVersion: 2019 - function * namedFn (...restArgs) {return 321} 1`] = `
+exports[`#123 - options.parse + ecmaVersion: 2019 - function * namedFn (...restArgs) {return 321} 1`] = `
 Object {
   "args": Array [
     "restArgs",
@@ -3951,6 +2834,7 @@ Object {
   "defaults": Object {
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -3964,37 +2848,12 @@ Object {
 }
 `;
 
-exports[`#114 - options.parse + ecmaVersion: 2019 - function * namedFn (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
-Object {
-  "args": Array [
-    "b",
-    "callback",
-    "restArgs",
-  ],
-  "body": "callback(null, b + 3)",
-  "defaults": Object {
-    "b": undefined,
-    "callback": undefined,
-    "restArgs": undefined,
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": true,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "b, callback, restArgs",
-  "value": "(function * namedFn (b, callback, ...restArgs) {callback(null, b + 3)})",
-}
-`;
-
-exports[`#115 - options.parse + ecmaVersion: 2019 - function * namedFn () {} 1`] = `
+exports[`#124 - options.parse + ecmaVersion: 2019 - function * namedFn () {} 1`] = `
 Object {
   "args": Array [],
   "body": "",
   "defaults": Object {},
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -4008,51 +2867,7 @@ Object {
 }
 `;
 
-exports[`#115 - options.parse + ecmaVersion: 2019 - function * namedFn (c) {return c * 3} 1`] = `
-Object {
-  "args": Array [
-    "c",
-  ],
-  "body": "return c * 3",
-  "defaults": Object {
-    "c": undefined,
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": true,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "c",
-  "value": "(function * namedFn (c) {return c * 3})",
-}
-`;
-
-exports[`#116 - options.parse + ecmaVersion: 2019 - function * namedFn (...restArgs) {return 321} 1`] = `
-Object {
-  "args": Array [
-    "restArgs",
-  ],
-  "body": "return 321",
-  "defaults": Object {
-    "restArgs": undefined,
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": true,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "restArgs",
-  "value": "(function * namedFn (...restArgs) {return 321})",
-}
-`;
-
-exports[`#116 - options.parse + ecmaVersion: 2019 - function * namedFn(a = (true, false)) {} 1`] = `
+exports[`#125 - options.parse + ecmaVersion: 2019 - function * namedFn(a = (true, false)) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -4061,6 +2876,7 @@ Object {
   "defaults": Object {
     "a": "false",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -4074,25 +2890,7 @@ Object {
 }
 `;
 
-exports[`#117 - options.parse + ecmaVersion: 2019 - function * namedFn () {} 1`] = `
-Object {
-  "args": Array [],
-  "body": "",
-  "defaults": Object {},
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": true,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "",
-  "value": "(function * namedFn () {})",
-}
-`;
-
-exports[`#117 - options.parse + ecmaVersion: 2019 - function * namedFn(a = (true, null)) {} 1`] = `
+exports[`#126 - options.parse + ecmaVersion: 2019 - function * namedFn(a = (true, null)) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -4101,6 +2899,7 @@ Object {
   "defaults": Object {
     "a": "null",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -4114,7 +2913,7 @@ Object {
 }
 `;
 
-exports[`#118 - options.parse + ecmaVersion: 2019 - function * namedFn(a = (true, "bar")) {} 1`] = `
+exports[`#127 - options.parse + ecmaVersion: 2019 - function * namedFn(a = (true, "bar")) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -4123,6 +2922,7 @@ Object {
   "defaults": Object {
     "a": "\\"bar\\"",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -4136,51 +2936,7 @@ Object {
 }
 `;
 
-exports[`#118 - options.parse + ecmaVersion: 2019 - function * namedFn(a = (true, false)) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "false",
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": true,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "a",
-  "value": "(function * namedFn(a = (true, false)) {})",
-}
-`;
-
-exports[`#119 - options.parse + ecmaVersion: 2019 - function * namedFn(a = (true, null)) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "null",
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": true,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "a",
-  "value": "(function * namedFn(a = (true, null)) {})",
-}
-`;
-
-exports[`#119 - options.parse + ecmaVersion: 2019 - function * namedFn(a, b = (i++, true)) {} 1`] = `
+exports[`#128 - options.parse + ecmaVersion: 2019 - function * namedFn(a, b = (i++, true)) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -4191,6 +2947,7 @@ Object {
     "a": undefined,
     "b": "true",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -4204,29 +2961,7 @@ Object {
 }
 `;
 
-exports[`#120 - options.parse + ecmaVersion: 2019 - function * namedFn(a = (true, "bar")) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "\\"bar\\"",
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": true,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "a",
-  "value": "(function * namedFn(a = (true, \\"bar\\")) {})",
-}
-`;
-
-exports[`#120 - options.parse + ecmaVersion: 2019 - function * namedFn(a = 1) {} 1`] = `
+exports[`#129 - options.parse + ecmaVersion: 2019 - function * namedFn(a = 1) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -4235,6 +2970,7 @@ Object {
   "defaults": Object {
     "a": "1",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -4248,7 +2984,33 @@ Object {
 }
 `;
 
-exports[`#121 - options.parse + ecmaVersion: 2019 - (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) => {return a * 3} 1`] = `
+exports[`#130 - options.parse + ecmaVersion: 2019 - function * namedFn({x, y}) {} 1`] = `
+Object {
+  "args": Array [
+    false,
+  ],
+  "body": "",
+  "defaults": Object {
+    "false": undefined,
+  },
+  "destructuredArgs": Array [
+    "x",
+    "y",
+  ],
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": true,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "false",
+  "value": "(function * namedFn({x, y}) {})",
+}
+`;
+
+exports[`#131 - options.parse + ecmaVersion: 2019 - (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) => {return a * 3} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -4261,6 +3023,7 @@ Object {
     "cb": undefined,
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -4274,31 +3037,7 @@ Object {
 }
 `;
 
-exports[`#121 - options.parse + ecmaVersion: 2019 - function * namedFn(a, b = (i++, true)) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-    "b",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": undefined,
-    "b": "true",
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": true,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "a, b",
-  "value": "(function * namedFn(a, b = (i++, true)) {})",
-}
-`;
-
-exports[`#122 - options.parse + ecmaVersion: 2019 - (b, callback, ...restArgs) => {callback(null, b + 3)} 1`] = `
+exports[`#132 - options.parse + ecmaVersion: 2019 - (b, callback, ...restArgs) => {callback(null, b + 3)} 1`] = `
 Object {
   "args": Array [
     "b",
@@ -4311,6 +3050,7 @@ Object {
     "callback": undefined,
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -4324,55 +3064,7 @@ Object {
 }
 `;
 
-exports[`#122 - options.parse + ecmaVersion: 2019 - function * namedFn(a = 1) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "1",
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": true,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "a",
-  "value": "(function * namedFn(a = 1) {})",
-}
-`;
-
-exports[`#123 - options.parse + ecmaVersion: 2019 - (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) => {return a * 3} 1`] = `
-Object {
-  "args": Array [
-    "a",
-    "cb",
-    "restArgs",
-  ],
-  "body": "return a * 3",
-  "defaults": Object {
-    "a": "{foo: \\"ba)r\\", baz: 123}",
-    "cb": undefined,
-    "restArgs": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a, cb, restArgs",
-  "value": "((a = {foo: \\"ba)r\\", baz: 123}, cb, ...restArgs) => {return a * 3})",
-}
-`;
-
-exports[`#123 - options.parse + ecmaVersion: 2019 - (c) => {return c * 3} 1`] = `
+exports[`#133 - options.parse + ecmaVersion: 2019 - (c) => {return c * 3} 1`] = `
 Object {
   "args": Array [
     "c",
@@ -4381,6 +3073,7 @@ Object {
   "defaults": Object {
     "c": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -4394,7 +3087,7 @@ Object {
 }
 `;
 
-exports[`#124 - options.parse + ecmaVersion: 2019 - (...restArgs) => {return 321} 1`] = `
+exports[`#134 - options.parse + ecmaVersion: 2019 - (...restArgs) => {return 321} 1`] = `
 Object {
   "args": Array [
     "restArgs",
@@ -4403,6 +3096,7 @@ Object {
   "defaults": Object {
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -4416,37 +3110,12 @@ Object {
 }
 `;
 
-exports[`#124 - options.parse + ecmaVersion: 2019 - (b, callback, ...restArgs) => {callback(null, b + 3)} 1`] = `
-Object {
-  "args": Array [
-    "b",
-    "callback",
-    "restArgs",
-  ],
-  "body": "callback(null, b + 3)",
-  "defaults": Object {
-    "b": undefined,
-    "callback": undefined,
-    "restArgs": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "b, callback, restArgs",
-  "value": "((b, callback, ...restArgs) => {callback(null, b + 3)})",
-}
-`;
-
-exports[`#125 - options.parse + ecmaVersion: 2019 - () => {} 1`] = `
+exports[`#135 - options.parse + ecmaVersion: 2019 - () => {} 1`] = `
 Object {
   "args": Array [],
   "body": "",
   "defaults": Object {},
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -4460,51 +3129,7 @@ Object {
 }
 `;
 
-exports[`#125 - options.parse + ecmaVersion: 2019 - (c) => {return c * 3} 1`] = `
-Object {
-  "args": Array [
-    "c",
-  ],
-  "body": "return c * 3",
-  "defaults": Object {
-    "c": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "c",
-  "value": "((c) => {return c * 3})",
-}
-`;
-
-exports[`#126 - options.parse + ecmaVersion: 2019 - (...restArgs) => {return 321} 1`] = `
-Object {
-  "args": Array [
-    "restArgs",
-  ],
-  "body": "return 321",
-  "defaults": Object {
-    "restArgs": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "restArgs",
-  "value": "((...restArgs) => {return 321})",
-}
-`;
-
-exports[`#126 - options.parse + ecmaVersion: 2019 - (a = (true, false)) => {} 1`] = `
+exports[`#136 - options.parse + ecmaVersion: 2019 - (a = (true, false)) => {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -4513,6 +3138,7 @@ Object {
   "defaults": Object {
     "a": "false",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -4526,25 +3152,7 @@ Object {
 }
 `;
 
-exports[`#127 - options.parse + ecmaVersion: 2019 - () => {} 1`] = `
-Object {
-  "args": Array [],
-  "body": "",
-  "defaults": Object {},
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "",
-  "value": "(() => {})",
-}
-`;
-
-exports[`#127 - options.parse + ecmaVersion: 2019 - (a = (true, null)) => {} 1`] = `
+exports[`#137 - options.parse + ecmaVersion: 2019 - (a = (true, null)) => {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -4553,6 +3161,7 @@ Object {
   "defaults": Object {
     "a": "null",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -4566,7 +3175,7 @@ Object {
 }
 `;
 
-exports[`#128 - options.parse + ecmaVersion: 2019 - (a = (true, "bar")) => {} 1`] = `
+exports[`#138 - options.parse + ecmaVersion: 2019 - (a = (true, "bar")) => {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -4575,6 +3184,7 @@ Object {
   "defaults": Object {
     "a": "\\"bar\\"",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -4588,51 +3198,7 @@ Object {
 }
 `;
 
-exports[`#128 - options.parse + ecmaVersion: 2019 - (a = (true, false)) => {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "false",
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "((a = (true, false)) => {})",
-}
-`;
-
-exports[`#129 - options.parse + ecmaVersion: 2019 - (a = (true, null)) => {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "null",
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "((a = (true, null)) => {})",
-}
-`;
-
-exports[`#129 - options.parse + ecmaVersion: 2019 - (a, b = (i++, true)) => {} 1`] = `
+exports[`#139 - options.parse + ecmaVersion: 2019 - (a, b = (i++, true)) => {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -4643,6 +3209,7 @@ Object {
     "a": undefined,
     "b": "true",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -4656,29 +3223,7 @@ Object {
 }
 `;
 
-exports[`#130 - options.parse + ecmaVersion: 2019 - (a = (true, "bar")) => {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "\\"bar\\"",
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "((a = (true, \\"bar\\")) => {})",
-}
-`;
-
-exports[`#130 - options.parse + ecmaVersion: 2019 - (a = 1) => {} 1`] = `
+exports[`#140 - options.parse + ecmaVersion: 2019 - (a = 1) => {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -4687,6 +3232,7 @@ Object {
   "defaults": Object {
     "a": "1",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -4700,7 +3246,7 @@ Object {
 }
 `;
 
-exports[`#131 - options.parse + ecmaVersion: 2019 - (a) => a * 3 * a 1`] = `
+exports[`#141 - options.parse + ecmaVersion: 2019 - (a) => a * 3 * a 1`] = `
 Object {
   "args": Array [
     "a",
@@ -4709,6 +3255,7 @@ Object {
   "defaults": Object {
     "a": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -4722,53 +3269,7 @@ Object {
 }
 `;
 
-exports[`#131 - options.parse + ecmaVersion: 2019 - (a, b = (i++, true)) => {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-    "b",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": undefined,
-    "b": "true",
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a, b",
-  "value": "((a, b = (i++, true)) => {})",
-}
-`;
-
-exports[`#132 - options.parse + ecmaVersion: 2019 - (a = 1) => {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "1",
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "((a = 1) => {})",
-}
-`;
-
-exports[`#132 - options.parse + ecmaVersion: 2019 - d => d * 355 * d 1`] = `
+exports[`#142 - options.parse + ecmaVersion: 2019 - d => d * 355 * d 1`] = `
 Object {
   "args": Array [
     "d",
@@ -4777,6 +3278,7 @@ Object {
   "defaults": Object {
     "d": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -4790,29 +3292,7 @@ Object {
 }
 `;
 
-exports[`#133 - options.parse + ecmaVersion: 2019 - (a) => a * 3 * a 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "a * 3 * a",
-  "defaults": Object {
-    "a": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "((a) => a * 3 * a)",
-}
-`;
-
-exports[`#133 - options.parse + ecmaVersion: 2019 - e => {return e + 5235 / e} 1`] = `
+exports[`#143 - options.parse + ecmaVersion: 2019 - e => {return e + 5235 / e} 1`] = `
 Object {
   "args": Array [
     "e",
@@ -4821,6 +3301,7 @@ Object {
   "defaults": Object {
     "e": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -4834,7 +3315,7 @@ Object {
 }
 `;
 
-exports[`#134 - options.parse + ecmaVersion: 2019 - (a, b) => a + 3 + b 1`] = `
+exports[`#144 - options.parse + ecmaVersion: 2019 - (a, b) => a + 3 + b 1`] = `
 Object {
   "args": Array [
     "a",
@@ -4845,6 +3326,7 @@ Object {
     "a": undefined,
     "b": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -4858,29 +3340,7 @@ Object {
 }
 `;
 
-exports[`#134 - options.parse + ecmaVersion: 2019 - d => d * 355 * d 1`] = `
-Object {
-  "args": Array [
-    "d",
-  ],
-  "body": "d * 355 * d",
-  "defaults": Object {
-    "d": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "d",
-  "value": "(d => d * 355 * d)",
-}
-`;
-
-exports[`#135 - options.parse + ecmaVersion: 2019 - (x, y, ...restArgs) => console.log({ value: x * y }) 1`] = `
+exports[`#145 - options.parse + ecmaVersion: 2019 - (x, y, ...restArgs) => console.log({ value: x * y }) 1`] = `
 Object {
   "args": Array [
     "x",
@@ -4893,6 +3353,7 @@ Object {
     "x": undefined,
     "y": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -4906,138 +3367,19 @@ Object {
 }
 `;
 
-exports[`#135 - options.parse + ecmaVersion: 2019 - e => {return e + 5235 / e} 1`] = `
+exports[`#146 - options.parse + ecmaVersion: 2019 - ({x, y}) => {} 1`] = `
 Object {
   "args": Array [
-    "e",
-  ],
-  "body": "return e + 5235 / e",
-  "defaults": Object {
-    "e": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "e",
-  "value": "(e => {return e + 5235 / e})",
-}
-`;
-
-exports[`#136 - options.parse + ecmaVersion: 2019 - (a, b) => a + 3 + b 1`] = `
-Object {
-  "args": Array [
-    "a",
-    "b",
-  ],
-  "body": "a + 3 + b",
-  "defaults": Object {
-    "a": undefined,
-    "b": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a, b",
-  "value": "((a, b) => a + 3 + b)",
-}
-`;
-
-exports[`#136 - options.parse + ecmaVersion: 2019 - async function (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
-Object {
-  "args": Array [
-    "a",
-    "cb",
-    "restArgs",
-  ],
-  "body": "return a * 3",
-  "defaults": Object {
-    "a": "{foo: \\"ba)r\\", baz: 123}",
-    "cb": undefined,
-    "restArgs": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a, cb, restArgs",
-  "value": "(async function (a = {foo: \\"ba)r\\", baz: 123}, cb, ...restArgs) {return a * 3})",
-}
-`;
-
-exports[`#137 - options.parse + ecmaVersion: 2019 - (x, y, ...restArgs) => console.log({ value: x * y }) 1`] = `
-Object {
-  "args": Array [
-    "x",
-    "y",
-    "restArgs",
-  ],
-  "body": "console.log({ value: x * y })",
-  "defaults": Object {
-    "restArgs": undefined,
-    "x": undefined,
-    "y": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "x, y, restArgs",
-  "value": "((x, y, ...restArgs) => console.log({ value: x * y }))",
-}
-`;
-
-exports[`#137 - options.parse + ecmaVersion: 2019 - async function (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
-Object {
-  "args": Array [
-    "b",
-    "callback",
-    "restArgs",
-  ],
-  "body": "callback(null, b + 3)",
-  "defaults": Object {
-    "b": undefined,
-    "callback": undefined,
-    "restArgs": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "b, callback, restArgs",
-  "value": "(async function (b, callback, ...restArgs) {callback(null, b + 3)})",
-}
-`;
-
-exports[`#138 - options.parse + ecmaVersion: 2019 - ({x, y}) => {} 1`] = `
-Object {
-  "args": Array [
-    "x",
-    "y",
+    false,
   ],
   "body": "",
-  "defaults": Object {},
+  "defaults": Object {
+    "false": undefined,
+  },
+  "destructuredArgs": Array [
+    "x",
+    "y",
+  ],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -5046,56 +3388,12 @@ Object {
   "isNamed": false,
   "isValid": true,
   "name": null,
-  "params": "x, y",
+  "params": "false",
   "value": "(({x, y}) => {})",
 }
 `;
 
-exports[`#138 - options.parse + ecmaVersion: 2019 - async function (c) {return c * 3} 1`] = `
-Object {
-  "args": Array [
-    "c",
-  ],
-  "body": "return c * 3",
-  "defaults": Object {
-    "c": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "c",
-  "value": "(async function (c) {return c * 3})",
-}
-`;
-
-exports[`#139 - options.parse + ecmaVersion: 2019 - async function (...restArgs) {return 321} 1`] = `
-Object {
-  "args": Array [
-    "restArgs",
-  ],
-  "body": "return 321",
-  "defaults": Object {
-    "restArgs": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "restArgs",
-  "value": "(async function (...restArgs) {return 321})",
-}
-`;
-
-exports[`#139 - options.parse + ecmaVersion: 2019 - async function (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
+exports[`#147 - options.parse + ecmaVersion: 2019 - async function (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -5108,6 +3406,7 @@ Object {
     "cb": undefined,
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": true,
@@ -5121,25 +3420,7 @@ Object {
 }
 `;
 
-exports[`#140 - options.parse + ecmaVersion: 2019 - async function () {} 1`] = `
-Object {
-  "args": Array [],
-  "body": "",
-  "defaults": Object {},
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "",
-  "value": "(async function () {})",
-}
-`;
-
-exports[`#140 - options.parse + ecmaVersion: 2019 - async function (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
+exports[`#148 - options.parse + ecmaVersion: 2019 - async function (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
 Object {
   "args": Array [
     "b",
@@ -5152,6 +3433,7 @@ Object {
     "callback": undefined,
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": true,
@@ -5165,29 +3447,7 @@ Object {
 }
 `;
 
-exports[`#141 - options.parse + ecmaVersion: 2019 - async function (a = (true, false)) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "false",
-  },
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "(async function (a = (true, false)) {})",
-}
-`;
-
-exports[`#141 - options.parse + ecmaVersion: 2019 - async function (c) {return c * 3} 1`] = `
+exports[`#149 - options.parse + ecmaVersion: 2019 - async function (c) {return c * 3} 1`] = `
 Object {
   "args": Array [
     "c",
@@ -5196,6 +3456,7 @@ Object {
   "defaults": Object {
     "c": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": true,
@@ -5209,7 +3470,7 @@ Object {
 }
 `;
 
-exports[`#142 - options.parse + ecmaVersion: 2019 - async function (...restArgs) {return 321} 1`] = `
+exports[`#150 - options.parse + ecmaVersion: 2019 - async function (...restArgs) {return 321} 1`] = `
 Object {
   "args": Array [
     "restArgs",
@@ -5218,6 +3479,7 @@ Object {
   "defaults": Object {
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": true,
@@ -5231,33 +3493,12 @@ Object {
 }
 `;
 
-exports[`#142 - options.parse + ecmaVersion: 2019 - async function (a = (true, null)) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "null",
-  },
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "(async function (a = (true, null)) {})",
-}
-`;
-
-exports[`#143 - options.parse + ecmaVersion: 2019 - async function () {} 1`] = `
+exports[`#151 - options.parse + ecmaVersion: 2019 - async function () {} 1`] = `
 Object {
   "args": Array [],
   "body": "",
   "defaults": Object {},
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": true,
@@ -5271,29 +3512,7 @@ Object {
 }
 `;
 
-exports[`#143 - options.parse + ecmaVersion: 2019 - async function (a = (true, "bar")) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "\\"bar\\"",
-  },
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "(async function (a = (true, \\"bar\\")) {})",
-}
-`;
-
-exports[`#144 - options.parse + ecmaVersion: 2019 - async function (a = (true, false)) {} 1`] = `
+exports[`#152 - options.parse + ecmaVersion: 2019 - async function (a = (true, false)) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -5302,6 +3521,7 @@ Object {
   "defaults": Object {
     "a": "false",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": true,
@@ -5315,31 +3535,7 @@ Object {
 }
 `;
 
-exports[`#144 - options.parse + ecmaVersion: 2019 - async function (a, b = (i++, true)) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-    "b",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": undefined,
-    "b": "true",
-  },
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a, b",
-  "value": "(async function (a, b = (i++, true)) {})",
-}
-`;
-
-exports[`#145 - options.parse + ecmaVersion: 2019 - async function (a = (true, null)) {} 1`] = `
+exports[`#153 - options.parse + ecmaVersion: 2019 - async function (a = (true, null)) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -5348,6 +3544,7 @@ Object {
   "defaults": Object {
     "a": "null",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": true,
@@ -5361,29 +3558,7 @@ Object {
 }
 `;
 
-exports[`#145 - options.parse + ecmaVersion: 2019 - async function (a = 1) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "1",
-  },
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "(async function (a = 1) {})",
-}
-`;
-
-exports[`#146 - options.parse + ecmaVersion: 2019 - async function (a = (true, "bar")) {} 1`] = `
+exports[`#154 - options.parse + ecmaVersion: 2019 - async function (a = (true, "bar")) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -5392,6 +3567,7 @@ Object {
   "defaults": Object {
     "a": "\\"bar\\"",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": true,
@@ -5405,33 +3581,7 @@ Object {
 }
 `;
 
-exports[`#146 - options.parse + ecmaVersion: 2019 - async function namedFn (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
-Object {
-  "args": Array [
-    "a",
-    "cb",
-    "restArgs",
-  ],
-  "body": "return a * 3",
-  "defaults": Object {
-    "a": "{foo: \\"ba)r\\", baz: 123}",
-    "cb": undefined,
-    "restArgs": undefined,
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "a, cb, restArgs",
-  "value": "(async function namedFn (a = {foo: \\"ba)r\\", baz: 123}, cb, ...restArgs) {return a * 3})",
-}
-`;
-
-exports[`#147 - options.parse + ecmaVersion: 2019 - async function (a, b = (i++, true)) {} 1`] = `
+exports[`#155 - options.parse + ecmaVersion: 2019 - async function (a, b = (i++, true)) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -5442,6 +3592,7 @@ Object {
     "a": undefined,
     "b": "true",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": true,
@@ -5455,33 +3606,7 @@ Object {
 }
 `;
 
-exports[`#147 - options.parse + ecmaVersion: 2019 - async function namedFn (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
-Object {
-  "args": Array [
-    "b",
-    "callback",
-    "restArgs",
-  ],
-  "body": "callback(null, b + 3)",
-  "defaults": Object {
-    "b": undefined,
-    "callback": undefined,
-    "restArgs": undefined,
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "b, callback, restArgs",
-  "value": "(async function namedFn (b, callback, ...restArgs) {callback(null, b + 3)})",
-}
-`;
-
-exports[`#148 - options.parse + ecmaVersion: 2019 - async function (a = 1) {} 1`] = `
+exports[`#156 - options.parse + ecmaVersion: 2019 - async function (a = 1) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -5490,6 +3615,7 @@ Object {
   "defaults": Object {
     "a": "1",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": true,
@@ -5503,51 +3629,33 @@ Object {
 }
 `;
 
-exports[`#148 - options.parse + ecmaVersion: 2019 - async function namedFn (c) {return c * 3} 1`] = `
+exports[`#157 - options.parse + ecmaVersion: 2019 - async function ({x, y}) {} 1`] = `
 Object {
   "args": Array [
-    "c",
+    false,
   ],
-  "body": "return c * 3",
+  "body": "",
   "defaults": Object {
-    "c": undefined,
+    "false": undefined,
   },
-  "isAnonymous": false,
+  "destructuredArgs": Array [
+    "x",
+    "y",
+  ],
+  "isAnonymous": true,
   "isArrow": false,
   "isAsync": true,
   "isExpression": false,
   "isGenerator": false,
-  "isNamed": true,
+  "isNamed": false,
   "isValid": true,
-  "name": "namedFn",
-  "params": "c",
-  "value": "(async function namedFn (c) {return c * 3})",
+  "name": null,
+  "params": "false",
+  "value": "(async function ({x, y}) {})",
 }
 `;
 
-exports[`#149 - options.parse + ecmaVersion: 2019 - async function namedFn (...restArgs) {return 321} 1`] = `
-Object {
-  "args": Array [
-    "restArgs",
-  ],
-  "body": "return 321",
-  "defaults": Object {
-    "restArgs": undefined,
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "restArgs",
-  "value": "(async function namedFn (...restArgs) {return 321})",
-}
-`;
-
-exports[`#149 - options.parse + ecmaVersion: 2019 - async function namedFn (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
+exports[`#158 - options.parse + ecmaVersion: 2019 - async function namedFn (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -5560,6 +3668,7 @@ Object {
     "cb": undefined,
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": true,
@@ -5573,25 +3682,7 @@ Object {
 }
 `;
 
-exports[`#150 - options.parse + ecmaVersion: 2019 - async function namedFn () {} 1`] = `
-Object {
-  "args": Array [],
-  "body": "",
-  "defaults": Object {},
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "",
-  "value": "(async function namedFn () {})",
-}
-`;
-
-exports[`#150 - options.parse + ecmaVersion: 2019 - async function namedFn (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
+exports[`#159 - options.parse + ecmaVersion: 2019 - async function namedFn (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
 Object {
   "args": Array [
     "b",
@@ -5604,6 +3695,7 @@ Object {
     "callback": undefined,
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": true,
@@ -5617,7 +3709,7 @@ Object {
 }
 `;
 
-exports[`#151 - options.parse + ecmaVersion: 2019 - async function namedFn (c) {return c * 3} 1`] = `
+exports[`#160 - options.parse + ecmaVersion: 2019 - async function namedFn (c) {return c * 3} 1`] = `
 Object {
   "args": Array [
     "c",
@@ -5626,6 +3718,7 @@ Object {
   "defaults": Object {
     "c": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": true,
@@ -5639,29 +3732,7 @@ Object {
 }
 `;
 
-exports[`#151 - options.parse + ecmaVersion: 2019 - async function namedFn(a = (true, false)) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "false",
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "a",
-  "value": "(async function namedFn(a = (true, false)) {})",
-}
-`;
-
-exports[`#152 - options.parse + ecmaVersion: 2019 - async function namedFn (...restArgs) {return 321} 1`] = `
+exports[`#161 - options.parse + ecmaVersion: 2019 - async function namedFn (...restArgs) {return 321} 1`] = `
 Object {
   "args": Array [
     "restArgs",
@@ -5670,6 +3741,7 @@ Object {
   "defaults": Object {
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": true,
@@ -5683,33 +3755,12 @@ Object {
 }
 `;
 
-exports[`#152 - options.parse + ecmaVersion: 2019 - async function namedFn(a = (true, null)) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "null",
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "a",
-  "value": "(async function namedFn(a = (true, null)) {})",
-}
-`;
-
-exports[`#153 - options.parse + ecmaVersion: 2019 - async function namedFn () {} 1`] = `
+exports[`#162 - options.parse + ecmaVersion: 2019 - async function namedFn () {} 1`] = `
 Object {
   "args": Array [],
   "body": "",
   "defaults": Object {},
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": true,
@@ -5723,29 +3774,7 @@ Object {
 }
 `;
 
-exports[`#153 - options.parse + ecmaVersion: 2019 - async function namedFn(a = (true, "bar")) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "\\"bar\\"",
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "a",
-  "value": "(async function namedFn(a = (true, \\"bar\\")) {})",
-}
-`;
-
-exports[`#154 - options.parse + ecmaVersion: 2019 - async function namedFn(a = (true, false)) {} 1`] = `
+exports[`#163 - options.parse + ecmaVersion: 2019 - async function namedFn(a = (true, false)) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -5754,6 +3783,7 @@ Object {
   "defaults": Object {
     "a": "false",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": true,
@@ -5767,31 +3797,7 @@ Object {
 }
 `;
 
-exports[`#154 - options.parse + ecmaVersion: 2019 - async function namedFn(a, b = (i++, true)) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-    "b",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": undefined,
-    "b": "true",
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "a, b",
-  "value": "(async function namedFn(a, b = (i++, true)) {})",
-}
-`;
-
-exports[`#155 - options.parse + ecmaVersion: 2019 - async function namedFn(a = (true, null)) {} 1`] = `
+exports[`#164 - options.parse + ecmaVersion: 2019 - async function namedFn(a = (true, null)) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -5800,6 +3806,7 @@ Object {
   "defaults": Object {
     "a": "null",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": true,
@@ -5813,55 +3820,7 @@ Object {
 }
 `;
 
-exports[`#155 - options.parse + ecmaVersion: 2019 - async function namedFn(a = 1) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "1",
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "a",
-  "value": "(async function namedFn(a = 1) {})",
-}
-`;
-
-exports[`#156 - options.parse + ecmaVersion: 2019 - async (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) => {return a * 3} 1`] = `
-Object {
-  "args": Array [
-    "a",
-    "cb",
-    "restArgs",
-  ],
-  "body": "return a * 3",
-  "defaults": Object {
-    "a": "{foo: \\"ba)r\\", baz: 123}",
-    "cb": undefined,
-    "restArgs": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a, cb, restArgs",
-  "value": "(async (a = {foo: \\"ba)r\\", baz: 123}, cb, ...restArgs) => {return a * 3})",
-}
-`;
-
-exports[`#156 - options.parse + ecmaVersion: 2019 - async function namedFn(a = (true, "bar")) {} 1`] = `
+exports[`#165 - options.parse + ecmaVersion: 2019 - async function namedFn(a = (true, "bar")) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -5870,6 +3829,7 @@ Object {
   "defaults": Object {
     "a": "\\"bar\\"",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": true,
@@ -5883,33 +3843,7 @@ Object {
 }
 `;
 
-exports[`#157 - options.parse + ecmaVersion: 2019 - async (b, callback, ...restArgs) => {callback(null, b + 3)} 1`] = `
-Object {
-  "args": Array [
-    "b",
-    "callback",
-    "restArgs",
-  ],
-  "body": "callback(null, b + 3)",
-  "defaults": Object {
-    "b": undefined,
-    "callback": undefined,
-    "restArgs": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "b, callback, restArgs",
-  "value": "(async (b, callback, ...restArgs) => {callback(null, b + 3)})",
-}
-`;
-
-exports[`#157 - options.parse + ecmaVersion: 2019 - async function namedFn(a, b = (i++, true)) {} 1`] = `
+exports[`#166 - options.parse + ecmaVersion: 2019 - async function namedFn(a, b = (i++, true)) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -5920,6 +3854,7 @@ Object {
     "a": undefined,
     "b": "true",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": true,
@@ -5933,29 +3868,7 @@ Object {
 }
 `;
 
-exports[`#158 - options.parse + ecmaVersion: 2019 - async (c) => {return c * 3} 1`] = `
-Object {
-  "args": Array [
-    "c",
-  ],
-  "body": "return c * 3",
-  "defaults": Object {
-    "c": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "c",
-  "value": "(async (c) => {return c * 3})",
-}
-`;
-
-exports[`#158 - options.parse + ecmaVersion: 2019 - async function namedFn(a = 1) {} 1`] = `
+exports[`#167 - options.parse + ecmaVersion: 2019 - async function namedFn(a = 1) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -5964,6 +3877,7 @@ Object {
   "defaults": Object {
     "a": "1",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": true,
@@ -5977,29 +3891,33 @@ Object {
 }
 `;
 
-exports[`#159 - options.parse + ecmaVersion: 2019 - async (...restArgs) => {return 321} 1`] = `
+exports[`#168 - options.parse + ecmaVersion: 2019 - async function namedFn({x, y}) {} 1`] = `
 Object {
   "args": Array [
-    "restArgs",
+    false,
   ],
-  "body": "return 321",
+  "body": "",
   "defaults": Object {
-    "restArgs": undefined,
+    "false": undefined,
   },
-  "isAnonymous": true,
-  "isArrow": true,
+  "destructuredArgs": Array [
+    "x",
+    "y",
+  ],
+  "isAnonymous": false,
+  "isArrow": false,
   "isAsync": true,
   "isExpression": false,
   "isGenerator": false,
-  "isNamed": false,
+  "isNamed": true,
   "isValid": true,
-  "name": null,
-  "params": "restArgs",
-  "value": "(async (...restArgs) => {return 321})",
+  "name": "namedFn",
+  "params": "false",
+  "value": "(async function namedFn({x, y}) {})",
 }
 `;
 
-exports[`#159 - options.parse + ecmaVersion: 2019 - async (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) => {return a * 3} 1`] = `
+exports[`#169 - options.parse + ecmaVersion: 2019 - async (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) => {return a * 3} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -6012,6 +3930,7 @@ Object {
     "cb": undefined,
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -6025,25 +3944,7 @@ Object {
 }
 `;
 
-exports[`#160 - options.parse + ecmaVersion: 2019 - async () => {} 1`] = `
-Object {
-  "args": Array [],
-  "body": "",
-  "defaults": Object {},
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "",
-  "value": "(async () => {})",
-}
-`;
-
-exports[`#160 - options.parse + ecmaVersion: 2019 - async (b, callback, ...restArgs) => {callback(null, b + 3)} 1`] = `
+exports[`#170 - options.parse + ecmaVersion: 2019 - async (b, callback, ...restArgs) => {callback(null, b + 3)} 1`] = `
 Object {
   "args": Array [
     "b",
@@ -6056,6 +3957,7 @@ Object {
     "callback": undefined,
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -6069,29 +3971,7 @@ Object {
 }
 `;
 
-exports[`#161 - options.parse + ecmaVersion: 2019 - async (a = (true, false)) => {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "false",
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "(async (a = (true, false)) => {})",
-}
-`;
-
-exports[`#161 - options.parse + ecmaVersion: 2019 - async (c) => {return c * 3} 1`] = `
+exports[`#171 - options.parse + ecmaVersion: 2019 - async (c) => {return c * 3} 1`] = `
 Object {
   "args": Array [
     "c",
@@ -6100,6 +3980,7 @@ Object {
   "defaults": Object {
     "c": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -6113,7 +3994,7 @@ Object {
 }
 `;
 
-exports[`#162 - options.parse + ecmaVersion: 2019 - async (...restArgs) => {return 321} 1`] = `
+exports[`#172 - options.parse + ecmaVersion: 2019 - async (...restArgs) => {return 321} 1`] = `
 Object {
   "args": Array [
     "restArgs",
@@ -6122,6 +4003,7 @@ Object {
   "defaults": Object {
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -6135,33 +4017,12 @@ Object {
 }
 `;
 
-exports[`#162 - options.parse + ecmaVersion: 2019 - async (a = (true, null)) => {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "null",
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "(async (a = (true, null)) => {})",
-}
-`;
-
-exports[`#163 - options.parse + ecmaVersion: 2019 - async () => {} 1`] = `
+exports[`#173 - options.parse + ecmaVersion: 2019 - async () => {} 1`] = `
 Object {
   "args": Array [],
   "body": "",
   "defaults": Object {},
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -6175,29 +4036,7 @@ Object {
 }
 `;
 
-exports[`#163 - options.parse + ecmaVersion: 2019 - async (a = (true, "bar")) => {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "\\"bar\\"",
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "(async (a = (true, \\"bar\\")) => {})",
-}
-`;
-
-exports[`#164 - options.parse + ecmaVersion: 2019 - async (a = (true, false)) => {} 1`] = `
+exports[`#174 - options.parse + ecmaVersion: 2019 - async (a = (true, false)) => {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -6206,6 +4045,7 @@ Object {
   "defaults": Object {
     "a": "false",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -6219,31 +4059,7 @@ Object {
 }
 `;
 
-exports[`#164 - options.parse + ecmaVersion: 2019 - async (a, b = (i++, true)) => {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-    "b",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": undefined,
-    "b": "true",
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a, b",
-  "value": "(async (a, b = (i++, true)) => {})",
-}
-`;
-
-exports[`#165 - options.parse + ecmaVersion: 2019 - async (a = (true, null)) => {} 1`] = `
+exports[`#175 - options.parse + ecmaVersion: 2019 - async (a = (true, null)) => {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -6252,6 +4068,7 @@ Object {
   "defaults": Object {
     "a": "null",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -6265,29 +4082,7 @@ Object {
 }
 `;
 
-exports[`#165 - options.parse + ecmaVersion: 2019 - async (a = 1) => {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "1",
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "(async (a = 1) => {})",
-}
-`;
-
-exports[`#166 - options.parse + ecmaVersion: 2019 - async (a = (true, "bar")) => {} 1`] = `
+exports[`#176 - options.parse + ecmaVersion: 2019 - async (a = (true, "bar")) => {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -6296,6 +4091,7 @@ Object {
   "defaults": Object {
     "a": "\\"bar\\"",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -6309,29 +4105,7 @@ Object {
 }
 `;
 
-exports[`#166 - options.parse + ecmaVersion: 2019 - async (a) => a * 3 * a 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "a * 3 * a",
-  "defaults": Object {
-    "a": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "(async (a) => a * 3 * a)",
-}
-`;
-
-exports[`#167 - options.parse + ecmaVersion: 2019 - async (a, b = (i++, true)) => {} 1`] = `
+exports[`#177 - options.parse + ecmaVersion: 2019 - async (a, b = (i++, true)) => {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -6342,6 +4116,7 @@ Object {
     "a": undefined,
     "b": "true",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -6355,29 +4130,7 @@ Object {
 }
 `;
 
-exports[`#167 - options.parse + ecmaVersion: 2019 - async d => d * 355 * d 1`] = `
-Object {
-  "args": Array [
-    "d",
-  ],
-  "body": "d * 355 * d",
-  "defaults": Object {
-    "d": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "d",
-  "value": "(async d => d * 355 * d)",
-}
-`;
-
-exports[`#168 - options.parse + ecmaVersion: 2019 - async (a = 1) => {} 1`] = `
+exports[`#178 - options.parse + ecmaVersion: 2019 - async (a = 1) => {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -6386,6 +4139,7 @@ Object {
   "defaults": Object {
     "a": "1",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -6399,29 +4153,7 @@ Object {
 }
 `;
 
-exports[`#168 - options.parse + ecmaVersion: 2019 - async e => {return e + 5235 / e} 1`] = `
-Object {
-  "args": Array [
-    "e",
-  ],
-  "body": "return e + 5235 / e",
-  "defaults": Object {
-    "e": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "e",
-  "value": "(async e => {return e + 5235 / e})",
-}
-`;
-
-exports[`#169 - options.parse + ecmaVersion: 2019 - async (a) => a * 3 * a 1`] = `
+exports[`#179 - options.parse + ecmaVersion: 2019 - async (a) => a * 3 * a 1`] = `
 Object {
   "args": Array [
     "a",
@@ -6430,6 +4162,7 @@ Object {
   "defaults": Object {
     "a": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -6443,57 +4176,7 @@ Object {
 }
 `;
 
-exports[`#169 - options.parse + ecmaVersion: 2019 - async (a, b) => a + 3 + b 1`] = `
-Object {
-  "args": Array [
-    "a",
-    "b",
-  ],
-  "body": "a + 3 + b",
-  "defaults": Object {
-    "a": undefined,
-    "b": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a, b",
-  "value": "(async (a, b) => a + 3 + b)",
-}
-`;
-
-exports[`#170 - options.parse + ecmaVersion: 2019 - async (x, y, ...restArgs) => console.log({ value: x * y }) 1`] = `
-Object {
-  "args": Array [
-    "x",
-    "y",
-    "restArgs",
-  ],
-  "body": "console.log({ value: x * y })",
-  "defaults": Object {
-    "restArgs": undefined,
-    "x": undefined,
-    "y": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "x, y, restArgs",
-  "value": "(async (x, y, ...restArgs) => console.log({ value: x * y }))",
-}
-`;
-
-exports[`#170 - options.parse + ecmaVersion: 2019 - async d => d * 355 * d 1`] = `
+exports[`#180 - options.parse + ecmaVersion: 2019 - async d => d * 355 * d 1`] = `
 Object {
   "args": Array [
     "d",
@@ -6502,6 +4185,7 @@ Object {
   "defaults": Object {
     "d": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -6515,7 +4199,7 @@ Object {
 }
 `;
 
-exports[`#171 - options.parse + ecmaVersion: 2019 - async e => {return e + 5235 / e} 1`] = `
+exports[`#181 - options.parse + ecmaVersion: 2019 - async e => {return e + 5235 / e} 1`] = `
 Object {
   "args": Array [
     "e",
@@ -6524,6 +4208,7 @@ Object {
   "defaults": Object {
     "e": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -6537,25 +4222,7 @@ Object {
 }
 `;
 
-exports[`#171 - options.parse + ecmaVersion: 2019 - should return object with default values when invalid 1`] = `
-Object {
-  "args": Array [],
-  "body": "",
-  "defaults": Object {},
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": false,
-  "name": null,
-  "params": "",
-  "value": "",
-}
-`;
-
-exports[`#172 - options.parse + ecmaVersion: 2019 - async (a, b) => a + 3 + b 1`] = `
+exports[`#182 - options.parse + ecmaVersion: 2019 - async (a, b) => a + 3 + b 1`] = `
 Object {
   "args": Array [
     "a",
@@ -6566,6 +4233,7 @@ Object {
     "a": undefined,
     "b": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -6579,25 +4247,7 @@ Object {
 }
 `;
 
-exports[`#172 - options.parse + ecmaVersion: 2019 - should have '.isValid' and few '.is*'' hidden properties 1`] = `
-Object {
-  "args": Array [],
-  "body": "",
-  "defaults": Object {},
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": false,
-  "name": null,
-  "params": "",
-  "value": "",
-}
-`;
-
-exports[`#173 - options.parse + ecmaVersion: 2019 - async (x, y, ...restArgs) => console.log({ value: x * y }) 1`] = `
+exports[`#183 - options.parse + ecmaVersion: 2019 - async (x, y, ...restArgs) => console.log({ value: x * y }) 1`] = `
 Object {
   "args": Array [
     "x",
@@ -6610,6 +4260,7 @@ Object {
     "x": undefined,
     "y": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -6623,14 +4274,19 @@ Object {
 }
 `;
 
-exports[`#174 - options.parse + ecmaVersion: 2019 - async ({x, y}) => {} 1`] = `
+exports[`#184 - options.parse + ecmaVersion: 2019 - async ({x, y}) => {} 1`] = `
 Object {
   "args": Array [
+    false,
+  ],
+  "body": "",
+  "defaults": Object {
+    "false": undefined,
+  },
+  "destructuredArgs": Array [
     "x",
     "y",
   ],
-  "body": "",
-  "defaults": Object {},
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -6639,12 +4295,12 @@ Object {
   "isNamed": false,
   "isValid": true,
   "name": null,
-  "params": "x, y",
+  "params": "false",
   "value": "(async ({x, y}) => {})",
 }
 `;
 
-exports[`#175 - options.parse + ecmaVersion: 2019 - should return object with default values when invalid 1`] = `
+exports[`#185 - options.parse + ecmaVersion: 2019 - should return object with default values when invalid 1`] = `
 Object {
   "args": Array [],
   "body": "",
@@ -6662,7 +4318,7 @@ Object {
 }
 `;
 
-exports[`#176 - options.parse + ecmaVersion: 2019 - should have '.isValid' and few '.is*'' hidden properties 1`] = `
+exports[`#186 - options.parse + ecmaVersion: 2019 - should have '.isValid' and few '.is*'' hidden properties 1`] = `
 Object {
   "args": Array [],
   "body": "",
@@ -6680,7 +4336,7 @@ Object {
 }
 `;
 
-exports[`#177 - options.parse + ecmaVersion: 2019 - should work for object methods 1`] = `
+exports[`#191 - options.parse + ecmaVersion: 2019 - should work for object methods 1`] = `
 Object {
   "args": Array [
     "a",
@@ -6695,6 +4351,7 @@ Object {
     "b": undefined,
     "c": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -6710,7 +4367,7 @@ Object {
 }
 `;
 
-exports[`#177 - options.parse + ecmaVersion: 2019 - should work for object methods 2`] = `
+exports[`#191 - options.parse + ecmaVersion: 2019 - should work for object methods 2`] = `
 Object {
   "args": Array [
     "a",
@@ -6721,6 +4378,7 @@ Object {
   "defaults": Object {
     "a": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -6736,7 +4394,7 @@ Object {
 }
 `;
 
-exports[`#177 - options.parse + ecmaVersion: 2019 - should work for object methods 3`] = `
+exports[`#191 - options.parse + ecmaVersion: 2019 - should work for object methods 3`] = `
 Object {
   "args": Array [
     "a",
@@ -6747,6 +4405,7 @@ Object {
   "defaults": Object {
     "a": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -6762,7 +4421,7 @@ Object {
 }
 `;
 
-exports[`#177 - options.parse + ecmaVersion: 2019 - should work for object methods 4`] = `
+exports[`#191 - options.parse + ecmaVersion: 2019 - should work for object methods 4`] = `
 Object {
   "args": Array [
     "a",
@@ -6775,6 +4434,7 @@ Object {
     "cb": undefined,
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -6788,7 +4448,7 @@ Object {
 }
 `;
 
-exports[`#181 - acorn.parse - function (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
+exports[`#195 - acorn.parse - function (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -6801,6 +4461,7 @@ Object {
     "cb": undefined,
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": false,
@@ -6814,115 +4475,7 @@ Object {
 }
 `;
 
-exports[`#181 - options.parse + ecmaVersion: 2019 - should work for object methods 1`] = `
-Object {
-  "args": Array [
-    "a",
-    "b",
-    "c",
-  ],
-  "body": "
-        return 123;
-      ",
-  "defaults": Object {
-    "a": undefined,
-    "b": undefined,
-    "c": undefined,
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "foo",
-  "params": "a, b, c",
-  "value": "({ foo(a, b, c) {
-        return 123;
-      } })",
-}
-`;
-
-exports[`#181 - options.parse + ecmaVersion: 2019 - should work for object methods 2`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "
-        return () => a;
-      ",
-  "defaults": Object {
-    "a": undefined,
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "bar",
-  "params": "a",
-  "value": "({ bar(a) {
-        return () => a;
-      } })",
-}
-`;
-
-exports[`#181 - options.parse + ecmaVersion: 2019 - should work for object methods 3`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "
-        return yield a * 321;
-      ",
-  "defaults": Object {
-    "a": undefined,
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": true,
-  "isNamed": true,
-  "isValid": true,
-  "name": "gen",
-  "params": "a",
-  "value": "({ *gen(a) {
-        return yield a * 321;
-      } })",
-}
-`;
-
-exports[`#181 - options.parse + ecmaVersion: 2019 - should work for object methods 4`] = `
-Object {
-  "args": Array [
-    "a",
-    "cb",
-    "restArgs",
-  ],
-  "body": " return a * 3 ",
-  "defaults": Object {
-    "a": "{foo: 'ba)r', baz: 123}",
-    "cb": undefined,
-    "restArgs": undefined,
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "a, cb, restArgs",
-  "value": "({ namedFn (a = {foo: 'ba)r', baz: 123}, cb, ...restArgs) { return a * 3 } })",
-}
-`;
-
-exports[`#182 - acorn.parse - function (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
+exports[`#196 - acorn.parse - function (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
 Object {
   "args": Array [
     "b",
@@ -6935,6 +4488,7 @@ Object {
     "callback": undefined,
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": false,
@@ -6948,7 +4502,7 @@ Object {
 }
 `;
 
-exports[`#183 - acorn.parse - function (c) {return c * 3} 1`] = `
+exports[`#197 - acorn.parse - function (c) {return c * 3} 1`] = `
 Object {
   "args": Array [
     "c",
@@ -6957,6 +4511,7 @@ Object {
   "defaults": Object {
     "c": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": false,
@@ -6970,7 +4525,7 @@ Object {
 }
 `;
 
-exports[`#184 - acorn.parse - function (...restArgs) {return 321} 1`] = `
+exports[`#198 - acorn.parse - function (...restArgs) {return 321} 1`] = `
 Object {
   "args": Array [
     "restArgs",
@@ -6979,6 +4534,7 @@ Object {
   "defaults": Object {
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": false,
@@ -6992,11 +4548,12 @@ Object {
 }
 `;
 
-exports[`#185 - acorn.parse - function () {} 1`] = `
+exports[`#199 - acorn.parse - function () {} 1`] = `
 Object {
   "args": Array [],
   "body": "",
   "defaults": Object {},
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": false,
@@ -7010,33 +4567,7 @@ Object {
 }
 `;
 
-exports[`#185 - acorn.parse - function (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
-Object {
-  "args": Array [
-    "a",
-    "cb",
-    "restArgs",
-  ],
-  "body": "return a * 3",
-  "defaults": Object {
-    "a": "{foo: \\"ba)r\\", baz: 123}",
-    "cb": undefined,
-    "restArgs": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a, cb, restArgs",
-  "value": "(function (a = {foo: \\"ba)r\\", baz: 123}, cb, ...restArgs) {return a * 3})",
-}
-`;
-
-exports[`#186 - acorn.parse - function (a = (true, false)) {} 1`] = `
+exports[`#200 - acorn.parse - function (a = (true, false)) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -7045,6 +4576,7 @@ Object {
   "defaults": Object {
     "a": "false",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": false,
@@ -7058,33 +4590,7 @@ Object {
 }
 `;
 
-exports[`#186 - acorn.parse - function (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
-Object {
-  "args": Array [
-    "b",
-    "callback",
-    "restArgs",
-  ],
-  "body": "callback(null, b + 3)",
-  "defaults": Object {
-    "b": undefined,
-    "callback": undefined,
-    "restArgs": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "b, callback, restArgs",
-  "value": "(function (b, callback, ...restArgs) {callback(null, b + 3)})",
-}
-`;
-
-exports[`#187 - acorn.parse - function (a = (true, null)) {} 1`] = `
+exports[`#201 - acorn.parse - function (a = (true, null)) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -7093,6 +4599,7 @@ Object {
   "defaults": Object {
     "a": "null",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": false,
@@ -7106,51 +4613,7 @@ Object {
 }
 `;
 
-exports[`#187 - acorn.parse - function (c) {return c * 3} 1`] = `
-Object {
-  "args": Array [
-    "c",
-  ],
-  "body": "return c * 3",
-  "defaults": Object {
-    "c": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "c",
-  "value": "(function (c) {return c * 3})",
-}
-`;
-
-exports[`#188 - acorn.parse - function (...restArgs) {return 321} 1`] = `
-Object {
-  "args": Array [
-    "restArgs",
-  ],
-  "body": "return 321",
-  "defaults": Object {
-    "restArgs": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "restArgs",
-  "value": "(function (...restArgs) {return 321})",
-}
-`;
-
-exports[`#188 - acorn.parse - function (a = (true, "bar")) {} 1`] = `
+exports[`#202 - acorn.parse - function (a = (true, "bar")) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -7159,6 +4622,7 @@ Object {
   "defaults": Object {
     "a": "\\"bar\\"",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": false,
@@ -7172,25 +4636,7 @@ Object {
 }
 `;
 
-exports[`#189 - acorn.parse - function () {} 1`] = `
-Object {
-  "args": Array [],
-  "body": "",
-  "defaults": Object {},
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "",
-  "value": "(function () {})",
-}
-`;
-
-exports[`#189 - acorn.parse - function (a, b = (i++, true)) {} 1`] = `
+exports[`#203 - acorn.parse - function (a, b = (i++, true)) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -7201,6 +4647,7 @@ Object {
     "a": undefined,
     "b": "true",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": false,
@@ -7214,29 +4661,7 @@ Object {
 }
 `;
 
-exports[`#190 - acorn.parse - function (a = (true, false)) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "false",
-  },
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "(function (a = (true, false)) {})",
-}
-`;
-
-exports[`#190 - acorn.parse - function (a = 1) {} 1`] = `
+exports[`#204 - acorn.parse - function (a = 1) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -7245,6 +4670,7 @@ Object {
   "defaults": Object {
     "a": "1",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": false,
@@ -7258,15 +4684,19 @@ Object {
 }
 `;
 
-exports[`#191 - acorn.parse - function (a = (true, null)) {} 1`] = `
+exports[`#205 - acorn.parse - function ({x, y}) {} 1`] = `
 Object {
   "args": Array [
-    "a",
+    false,
   ],
   "body": "",
   "defaults": Object {
-    "a": "null",
+    "false": undefined,
   },
+  "destructuredArgs": Array [
+    "x",
+    "y",
+  ],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": false,
@@ -7275,12 +4705,12 @@ Object {
   "isNamed": false,
   "isValid": true,
   "name": null,
-  "params": "a",
-  "value": "(function (a = (true, null)) {})",
+  "params": "false",
+  "value": "(function ({x, y}) {})",
 }
 `;
 
-exports[`#191 - acorn.parse - function namedFn (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
+exports[`#206 - acorn.parse - function namedFn (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -7293,6 +4723,7 @@ Object {
     "cb": undefined,
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -7306,29 +4737,7 @@ Object {
 }
 `;
 
-exports[`#192 - acorn.parse - function (a = (true, "bar")) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "\\"bar\\"",
-  },
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "(function (a = (true, \\"bar\\")) {})",
-}
-`;
-
-exports[`#192 - acorn.parse - function namedFn (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
+exports[`#207 - acorn.parse - function namedFn (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
 Object {
   "args": Array [
     "b",
@@ -7341,6 +4750,7 @@ Object {
     "callback": undefined,
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -7354,31 +4764,7 @@ Object {
 }
 `;
 
-exports[`#193 - acorn.parse - function (a, b = (i++, true)) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-    "b",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": undefined,
-    "b": "true",
-  },
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a, b",
-  "value": "(function (a, b = (i++, true)) {})",
-}
-`;
-
-exports[`#193 - acorn.parse - function namedFn (c) {return c * 3} 1`] = `
+exports[`#208 - acorn.parse - function namedFn (c) {return c * 3} 1`] = `
 Object {
   "args": Array [
     "c",
@@ -7387,6 +4773,7 @@ Object {
   "defaults": Object {
     "c": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -7400,29 +4787,7 @@ Object {
 }
 `;
 
-exports[`#194 - acorn.parse - function (a = 1) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "1",
-  },
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "(function (a = 1) {})",
-}
-`;
-
-exports[`#194 - acorn.parse - function namedFn (...restArgs) {return 321} 1`] = `
+exports[`#209 - acorn.parse - function namedFn (...restArgs) {return 321} 1`] = `
 Object {
   "args": Array [
     "restArgs",
@@ -7431,6 +4796,7 @@ Object {
   "defaults": Object {
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -7444,11 +4810,12 @@ Object {
 }
 `;
 
-exports[`#195 - acorn.parse - function namedFn () {} 1`] = `
+exports[`#210 - acorn.parse - function namedFn () {} 1`] = `
 Object {
   "args": Array [],
   "body": "",
   "defaults": Object {},
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -7462,59 +4829,7 @@ Object {
 }
 `;
 
-exports[`#195 - acorn.parse - function namedFn (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
-Object {
-  "args": Array [
-    "a",
-    "cb",
-    "restArgs",
-  ],
-  "body": "return a * 3",
-  "defaults": Object {
-    "a": "{foo: \\"ba)r\\", baz: 123}",
-    "cb": undefined,
-    "restArgs": undefined,
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "a, cb, restArgs",
-  "value": "(function namedFn (a = {foo: \\"ba)r\\", baz: 123}, cb, ...restArgs) {return a * 3})",
-}
-`;
-
-exports[`#196 - acorn.parse - function namedFn (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
-Object {
-  "args": Array [
-    "b",
-    "callback",
-    "restArgs",
-  ],
-  "body": "callback(null, b + 3)",
-  "defaults": Object {
-    "b": undefined,
-    "callback": undefined,
-    "restArgs": undefined,
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "b, callback, restArgs",
-  "value": "(function namedFn (b, callback, ...restArgs) {callback(null, b + 3)})",
-}
-`;
-
-exports[`#196 - acorn.parse - function namedFn(a = (true, false)) {} 1`] = `
+exports[`#211 - acorn.parse - function namedFn(a = (true, false)) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -7523,6 +4838,7 @@ Object {
   "defaults": Object {
     "a": "false",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -7536,29 +4852,7 @@ Object {
 }
 `;
 
-exports[`#197 - acorn.parse - function namedFn (c) {return c * 3} 1`] = `
-Object {
-  "args": Array [
-    "c",
-  ],
-  "body": "return c * 3",
-  "defaults": Object {
-    "c": undefined,
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "c",
-  "value": "(function namedFn (c) {return c * 3})",
-}
-`;
-
-exports[`#197 - acorn.parse - function namedFn(a = (true, null)) {} 1`] = `
+exports[`#212 - acorn.parse - function namedFn(a = (true, null)) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -7567,6 +4861,7 @@ Object {
   "defaults": Object {
     "a": "null",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -7580,29 +4875,7 @@ Object {
 }
 `;
 
-exports[`#198 - acorn.parse - function namedFn (...restArgs) {return 321} 1`] = `
-Object {
-  "args": Array [
-    "restArgs",
-  ],
-  "body": "return 321",
-  "defaults": Object {
-    "restArgs": undefined,
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "restArgs",
-  "value": "(function namedFn (...restArgs) {return 321})",
-}
-`;
-
-exports[`#198 - acorn.parse - function namedFn(a = (true, "bar")) {} 1`] = `
+exports[`#213 - acorn.parse - function namedFn(a = (true, "bar")) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -7611,6 +4884,7 @@ Object {
   "defaults": Object {
     "a": "\\"bar\\"",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -7624,25 +4898,7 @@ Object {
 }
 `;
 
-exports[`#199 - acorn.parse - function namedFn () {} 1`] = `
-Object {
-  "args": Array [],
-  "body": "",
-  "defaults": Object {},
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "",
-  "value": "(function namedFn () {})",
-}
-`;
-
-exports[`#199 - acorn.parse - function namedFn(a, b = (i++, true)) {} 1`] = `
+exports[`#214 - acorn.parse - function namedFn(a, b = (i++, true)) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -7653,6 +4909,7 @@ Object {
     "a": undefined,
     "b": "true",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -7666,29 +4923,7 @@ Object {
 }
 `;
 
-exports[`#200 - acorn.parse - function namedFn(a = (true, false)) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "false",
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "a",
-  "value": "(function namedFn(a = (true, false)) {})",
-}
-`;
-
-exports[`#200 - acorn.parse - function namedFn(a = 1) {} 1`] = `
+exports[`#215 - acorn.parse - function namedFn(a = 1) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -7697,6 +4932,7 @@ Object {
   "defaults": Object {
     "a": "1",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -7710,7 +4946,33 @@ Object {
 }
 `;
 
-exports[`#201 - acorn.parse - function * namedFn (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
+exports[`#216 - acorn.parse - function namedFn({x, y}) {} 1`] = `
+Object {
+  "args": Array [
+    false,
+  ],
+  "body": "",
+  "defaults": Object {
+    "false": undefined,
+  },
+  "destructuredArgs": Array [
+    "x",
+    "y",
+  ],
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "false",
+  "value": "(function namedFn({x, y}) {})",
+}
+`;
+
+exports[`#217 - acorn.parse - function * namedFn (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -7723,6 +4985,7 @@ Object {
     "cb": undefined,
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -7736,29 +4999,7 @@ Object {
 }
 `;
 
-exports[`#201 - acorn.parse - function namedFn(a = (true, null)) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "null",
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "a",
-  "value": "(function namedFn(a = (true, null)) {})",
-}
-`;
-
-exports[`#202 - acorn.parse - function * namedFn (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
+exports[`#218 - acorn.parse - function * namedFn (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
 Object {
   "args": Array [
     "b",
@@ -7771,6 +5012,7 @@ Object {
     "callback": undefined,
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -7784,29 +5026,7 @@ Object {
 }
 `;
 
-exports[`#202 - acorn.parse - function namedFn(a = (true, "bar")) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "\\"bar\\"",
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "a",
-  "value": "(function namedFn(a = (true, \\"bar\\")) {})",
-}
-`;
-
-exports[`#203 - acorn.parse - function * namedFn (c) {return c * 3} 1`] = `
+exports[`#219 - acorn.parse - function * namedFn (c) {return c * 3} 1`] = `
 Object {
   "args": Array [
     "c",
@@ -7815,6 +5035,7 @@ Object {
   "defaults": Object {
     "c": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -7828,31 +5049,7 @@ Object {
 }
 `;
 
-exports[`#203 - acorn.parse - function namedFn(a, b = (i++, true)) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-    "b",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": undefined,
-    "b": "true",
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "a, b",
-  "value": "(function namedFn(a, b = (i++, true)) {})",
-}
-`;
-
-exports[`#204 - acorn.parse - function * namedFn (...restArgs) {return 321} 1`] = `
+exports[`#220 - acorn.parse - function * namedFn (...restArgs) {return 321} 1`] = `
 Object {
   "args": Array [
     "restArgs",
@@ -7861,6 +5058,7 @@ Object {
   "defaults": Object {
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -7874,33 +5072,12 @@ Object {
 }
 `;
 
-exports[`#204 - acorn.parse - function namedFn(a = 1) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "1",
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "a",
-  "value": "(function namedFn(a = 1) {})",
-}
-`;
-
-exports[`#205 - acorn.parse - function * namedFn () {} 1`] = `
+exports[`#221 - acorn.parse - function * namedFn () {} 1`] = `
 Object {
   "args": Array [],
   "body": "",
   "defaults": Object {},
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -7914,59 +5091,7 @@ Object {
 }
 `;
 
-exports[`#205 - acorn.parse - function * namedFn (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
-Object {
-  "args": Array [
-    "a",
-    "cb",
-    "restArgs",
-  ],
-  "body": "return a * 3",
-  "defaults": Object {
-    "a": "{foo: \\"ba)r\\", baz: 123}",
-    "cb": undefined,
-    "restArgs": undefined,
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": true,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "a, cb, restArgs",
-  "value": "(function * namedFn (a = {foo: \\"ba)r\\", baz: 123}, cb, ...restArgs) {return a * 3})",
-}
-`;
-
-exports[`#206 - acorn.parse - function * namedFn (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
-Object {
-  "args": Array [
-    "b",
-    "callback",
-    "restArgs",
-  ],
-  "body": "callback(null, b + 3)",
-  "defaults": Object {
-    "b": undefined,
-    "callback": undefined,
-    "restArgs": undefined,
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": true,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "b, callback, restArgs",
-  "value": "(function * namedFn (b, callback, ...restArgs) {callback(null, b + 3)})",
-}
-`;
-
-exports[`#206 - acorn.parse - function * namedFn(a = (true, false)) {} 1`] = `
+exports[`#222 - acorn.parse - function * namedFn(a = (true, false)) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -7975,6 +5100,7 @@ Object {
   "defaults": Object {
     "a": "false",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -7988,29 +5114,7 @@ Object {
 }
 `;
 
-exports[`#207 - acorn.parse - function * namedFn (c) {return c * 3} 1`] = `
-Object {
-  "args": Array [
-    "c",
-  ],
-  "body": "return c * 3",
-  "defaults": Object {
-    "c": undefined,
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": true,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "c",
-  "value": "(function * namedFn (c) {return c * 3})",
-}
-`;
-
-exports[`#207 - acorn.parse - function * namedFn(a = (true, null)) {} 1`] = `
+exports[`#223 - acorn.parse - function * namedFn(a = (true, null)) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -8019,6 +5123,7 @@ Object {
   "defaults": Object {
     "a": "null",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -8032,29 +5137,7 @@ Object {
 }
 `;
 
-exports[`#208 - acorn.parse - function * namedFn (...restArgs) {return 321} 1`] = `
-Object {
-  "args": Array [
-    "restArgs",
-  ],
-  "body": "return 321",
-  "defaults": Object {
-    "restArgs": undefined,
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": true,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "restArgs",
-  "value": "(function * namedFn (...restArgs) {return 321})",
-}
-`;
-
-exports[`#208 - acorn.parse - function * namedFn(a = (true, "bar")) {} 1`] = `
+exports[`#224 - acorn.parse - function * namedFn(a = (true, "bar")) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -8063,6 +5146,7 @@ Object {
   "defaults": Object {
     "a": "\\"bar\\"",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -8076,25 +5160,7 @@ Object {
 }
 `;
 
-exports[`#209 - acorn.parse - function * namedFn () {} 1`] = `
-Object {
-  "args": Array [],
-  "body": "",
-  "defaults": Object {},
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": true,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "",
-  "value": "(function * namedFn () {})",
-}
-`;
-
-exports[`#209 - acorn.parse - function * namedFn(a, b = (i++, true)) {} 1`] = `
+exports[`#225 - acorn.parse - function * namedFn(a, b = (i++, true)) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -8105,6 +5171,7 @@ Object {
     "a": undefined,
     "b": "true",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -8118,29 +5185,7 @@ Object {
 }
 `;
 
-exports[`#210 - acorn.parse - function * namedFn(a = (true, false)) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "false",
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": true,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "a",
-  "value": "(function * namedFn(a = (true, false)) {})",
-}
-`;
-
-exports[`#210 - acorn.parse - function * namedFn(a = 1) {} 1`] = `
+exports[`#226 - acorn.parse - function * namedFn(a = 1) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -8149,6 +5194,7 @@ Object {
   "defaults": Object {
     "a": "1",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -8162,7 +5208,33 @@ Object {
 }
 `;
 
-exports[`#211 - acorn.parse - (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) => {return a * 3} 1`] = `
+exports[`#227 - acorn.parse - function * namedFn({x, y}) {} 1`] = `
+Object {
+  "args": Array [
+    false,
+  ],
+  "body": "",
+  "defaults": Object {
+    "false": undefined,
+  },
+  "destructuredArgs": Array [
+    "x",
+    "y",
+  ],
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": true,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "false",
+  "value": "(function * namedFn({x, y}) {})",
+}
+`;
+
+exports[`#228 - acorn.parse - (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) => {return a * 3} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -8175,6 +5247,7 @@ Object {
     "cb": undefined,
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -8188,29 +5261,7 @@ Object {
 }
 `;
 
-exports[`#211 - acorn.parse - function * namedFn(a = (true, null)) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "null",
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": true,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "a",
-  "value": "(function * namedFn(a = (true, null)) {})",
-}
-`;
-
-exports[`#212 - acorn.parse - (b, callback, ...restArgs) => {callback(null, b + 3)} 1`] = `
+exports[`#229 - acorn.parse - (b, callback, ...restArgs) => {callback(null, b + 3)} 1`] = `
 Object {
   "args": Array [
     "b",
@@ -8223,6 +5274,7 @@ Object {
     "callback": undefined,
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -8236,29 +5288,7 @@ Object {
 }
 `;
 
-exports[`#212 - acorn.parse - function * namedFn(a = (true, "bar")) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "\\"bar\\"",
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": true,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "a",
-  "value": "(function * namedFn(a = (true, \\"bar\\")) {})",
-}
-`;
-
-exports[`#213 - acorn.parse - (c) => {return c * 3} 1`] = `
+exports[`#230 - acorn.parse - (c) => {return c * 3} 1`] = `
 Object {
   "args": Array [
     "c",
@@ -8267,6 +5297,7 @@ Object {
   "defaults": Object {
     "c": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -8280,31 +5311,7 @@ Object {
 }
 `;
 
-exports[`#213 - acorn.parse - function * namedFn(a, b = (i++, true)) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-    "b",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": undefined,
-    "b": "true",
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": true,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "a, b",
-  "value": "(function * namedFn(a, b = (i++, true)) {})",
-}
-`;
-
-exports[`#214 - acorn.parse - (...restArgs) => {return 321} 1`] = `
+exports[`#231 - acorn.parse - (...restArgs) => {return 321} 1`] = `
 Object {
   "args": Array [
     "restArgs",
@@ -8313,6 +5320,7 @@ Object {
   "defaults": Object {
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -8326,33 +5334,12 @@ Object {
 }
 `;
 
-exports[`#214 - acorn.parse - function * namedFn(a = 1) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "1",
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": true,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "a",
-  "value": "(function * namedFn(a = 1) {})",
-}
-`;
-
-exports[`#215 - acorn.parse - () => {} 1`] = `
+exports[`#232 - acorn.parse - () => {} 1`] = `
 Object {
   "args": Array [],
   "body": "",
   "defaults": Object {},
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -8366,33 +5353,7 @@ Object {
 }
 `;
 
-exports[`#215 - acorn.parse - (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) => {return a * 3} 1`] = `
-Object {
-  "args": Array [
-    "a",
-    "cb",
-    "restArgs",
-  ],
-  "body": "return a * 3",
-  "defaults": Object {
-    "a": "{foo: \\"ba)r\\", baz: 123}",
-    "cb": undefined,
-    "restArgs": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a, cb, restArgs",
-  "value": "((a = {foo: \\"ba)r\\", baz: 123}, cb, ...restArgs) => {return a * 3})",
-}
-`;
-
-exports[`#216 - acorn.parse - (a = (true, false)) => {} 1`] = `
+exports[`#233 - acorn.parse - (a = (true, false)) => {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -8401,6 +5362,7 @@ Object {
   "defaults": Object {
     "a": "false",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -8414,33 +5376,7 @@ Object {
 }
 `;
 
-exports[`#216 - acorn.parse - (b, callback, ...restArgs) => {callback(null, b + 3)} 1`] = `
-Object {
-  "args": Array [
-    "b",
-    "callback",
-    "restArgs",
-  ],
-  "body": "callback(null, b + 3)",
-  "defaults": Object {
-    "b": undefined,
-    "callback": undefined,
-    "restArgs": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "b, callback, restArgs",
-  "value": "((b, callback, ...restArgs) => {callback(null, b + 3)})",
-}
-`;
-
-exports[`#217 - acorn.parse - (a = (true, null)) => {} 1`] = `
+exports[`#234 - acorn.parse - (a = (true, null)) => {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -8449,6 +5385,7 @@ Object {
   "defaults": Object {
     "a": "null",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -8462,51 +5399,7 @@ Object {
 }
 `;
 
-exports[`#217 - acorn.parse - (c) => {return c * 3} 1`] = `
-Object {
-  "args": Array [
-    "c",
-  ],
-  "body": "return c * 3",
-  "defaults": Object {
-    "c": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "c",
-  "value": "((c) => {return c * 3})",
-}
-`;
-
-exports[`#218 - acorn.parse - (...restArgs) => {return 321} 1`] = `
-Object {
-  "args": Array [
-    "restArgs",
-  ],
-  "body": "return 321",
-  "defaults": Object {
-    "restArgs": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "restArgs",
-  "value": "((...restArgs) => {return 321})",
-}
-`;
-
-exports[`#218 - acorn.parse - (a = (true, "bar")) => {} 1`] = `
+exports[`#235 - acorn.parse - (a = (true, "bar")) => {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -8515,6 +5408,7 @@ Object {
   "defaults": Object {
     "a": "\\"bar\\"",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -8528,25 +5422,7 @@ Object {
 }
 `;
 
-exports[`#219 - acorn.parse - () => {} 1`] = `
-Object {
-  "args": Array [],
-  "body": "",
-  "defaults": Object {},
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "",
-  "value": "(() => {})",
-}
-`;
-
-exports[`#219 - acorn.parse - (a, b = (i++, true)) => {} 1`] = `
+exports[`#236 - acorn.parse - (a, b = (i++, true)) => {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -8557,6 +5433,7 @@ Object {
     "a": undefined,
     "b": "true",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -8570,29 +5447,7 @@ Object {
 }
 `;
 
-exports[`#220 - acorn.parse - (a = (true, false)) => {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "false",
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "((a = (true, false)) => {})",
-}
-`;
-
-exports[`#220 - acorn.parse - (a = 1) => {} 1`] = `
+exports[`#237 - acorn.parse - (a = 1) => {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -8601,6 +5456,7 @@ Object {
   "defaults": Object {
     "a": "1",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -8614,29 +5470,7 @@ Object {
 }
 `;
 
-exports[`#221 - acorn.parse - (a = (true, null)) => {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "null",
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "((a = (true, null)) => {})",
-}
-`;
-
-exports[`#221 - acorn.parse - (a) => a * 3 * a 1`] = `
+exports[`#238 - acorn.parse - (a) => a * 3 * a 1`] = `
 Object {
   "args": Array [
     "a",
@@ -8645,6 +5479,7 @@ Object {
   "defaults": Object {
     "a": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -8658,29 +5493,7 @@ Object {
 }
 `;
 
-exports[`#222 - acorn.parse - (a = (true, "bar")) => {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "\\"bar\\"",
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "((a = (true, \\"bar\\")) => {})",
-}
-`;
-
-exports[`#222 - acorn.parse - d => d * 355 * d 1`] = `
+exports[`#239 - acorn.parse - d => d * 355 * d 1`] = `
 Object {
   "args": Array [
     "d",
@@ -8689,6 +5502,7 @@ Object {
   "defaults": Object {
     "d": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -8702,31 +5516,7 @@ Object {
 }
 `;
 
-exports[`#223 - acorn.parse - (a, b = (i++, true)) => {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-    "b",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": undefined,
-    "b": "true",
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a, b",
-  "value": "((a, b = (i++, true)) => {})",
-}
-`;
-
-exports[`#223 - acorn.parse - e => {return e + 5235 / e} 1`] = `
+exports[`#240 - acorn.parse - e => {return e + 5235 / e} 1`] = `
 Object {
   "args": Array [
     "e",
@@ -8735,6 +5525,7 @@ Object {
   "defaults": Object {
     "e": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -8748,29 +5539,7 @@ Object {
 }
 `;
 
-exports[`#224 - acorn.parse - (a = 1) => {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "1",
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "((a = 1) => {})",
-}
-`;
-
-exports[`#224 - acorn.parse - (a, b) => a + 3 + b 1`] = `
+exports[`#241 - acorn.parse - (a, b) => a + 3 + b 1`] = `
 Object {
   "args": Array [
     "a",
@@ -8781,6 +5550,7 @@ Object {
     "a": undefined,
     "b": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -8794,29 +5564,7 @@ Object {
 }
 `;
 
-exports[`#225 - acorn.parse - (a) => a * 3 * a 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "a * 3 * a",
-  "defaults": Object {
-    "a": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": false,
-  "isExpression": true,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "((a) => a * 3 * a)",
-}
-`;
-
-exports[`#225 - acorn.parse - (x, y, ...restArgs) => console.log({ value: x * y }) 1`] = `
+exports[`#242 - acorn.parse - (x, y, ...restArgs) => console.log({ value: x * y }) 1`] = `
 Object {
   "args": Array [
     "x",
@@ -8829,6 +5577,7 @@ Object {
     "x": undefined,
     "y": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -8842,204 +5591,19 @@ Object {
 }
 `;
 
-exports[`#226 - acorn.parse - async function (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
+exports[`#243 - acorn.parse - ({x, y}) => {} 1`] = `
 Object {
   "args": Array [
-    "a",
-    "cb",
-    "restArgs",
-  ],
-  "body": "return a * 3",
-  "defaults": Object {
-    "a": "{foo: \\"ba)r\\", baz: 123}",
-    "cb": undefined,
-    "restArgs": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a, cb, restArgs",
-  "value": "(async function (a = {foo: \\"ba)r\\", baz: 123}, cb, ...restArgs) {return a * 3})",
-}
-`;
-
-exports[`#226 - acorn.parse - d => d * 355 * d 1`] = `
-Object {
-  "args": Array [
-    "d",
-  ],
-  "body": "d * 355 * d",
-  "defaults": Object {
-    "d": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": false,
-  "isExpression": true,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "d",
-  "value": "(d => d * 355 * d)",
-}
-`;
-
-exports[`#227 - acorn.parse - async function (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
-Object {
-  "args": Array [
-    "b",
-    "callback",
-    "restArgs",
-  ],
-  "body": "callback(null, b + 3)",
-  "defaults": Object {
-    "b": undefined,
-    "callback": undefined,
-    "restArgs": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "b, callback, restArgs",
-  "value": "(async function (b, callback, ...restArgs) {callback(null, b + 3)})",
-}
-`;
-
-exports[`#227 - acorn.parse - e => {return e + 5235 / e} 1`] = `
-Object {
-  "args": Array [
-    "e",
-  ],
-  "body": "return e + 5235 / e",
-  "defaults": Object {
-    "e": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "e",
-  "value": "(e => {return e + 5235 / e})",
-}
-`;
-
-exports[`#228 - acorn.parse - (a, b) => a + 3 + b 1`] = `
-Object {
-  "args": Array [
-    "a",
-    "b",
-  ],
-  "body": "a + 3 + b",
-  "defaults": Object {
-    "a": undefined,
-    "b": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": false,
-  "isExpression": true,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a, b",
-  "value": "((a, b) => a + 3 + b)",
-}
-`;
-
-exports[`#228 - acorn.parse - async function (c) {return c * 3} 1`] = `
-Object {
-  "args": Array [
-    "c",
-  ],
-  "body": "return c * 3",
-  "defaults": Object {
-    "c": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "c",
-  "value": "(async function (c) {return c * 3})",
-}
-`;
-
-exports[`#229 - acorn.parse - (x, y, ...restArgs) => console.log({ value: x * y }) 1`] = `
-Object {
-  "args": Array [
-    "x",
-    "y",
-    "restArgs",
-  ],
-  "body": "console.log({ value: x * y })",
-  "defaults": Object {
-    "restArgs": undefined,
-    "x": undefined,
-    "y": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": false,
-  "isExpression": true,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "x, y, restArgs",
-  "value": "((x, y, ...restArgs) => console.log({ value: x * y }))",
-}
-`;
-
-exports[`#229 - acorn.parse - async function (...restArgs) {return 321} 1`] = `
-Object {
-  "args": Array [
-    "restArgs",
-  ],
-  "body": "return 321",
-  "defaults": Object {
-    "restArgs": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "restArgs",
-  "value": "(async function (...restArgs) {return 321})",
-}
-`;
-
-exports[`#230 - acorn.parse - ({x, y}) => {} 1`] = `
-Object {
-  "args": Array [
-    "x",
-    "y",
+    false,
   ],
   "body": "",
-  "defaults": Object {},
+  "defaults": Object {
+    "false": undefined,
+  },
+  "destructuredArgs": Array [
+    "x",
+    "y",
+  ],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -9048,52 +5612,12 @@ Object {
   "isNamed": false,
   "isValid": true,
   "name": null,
-  "params": "x, y",
+  "params": "false",
   "value": "(({x, y}) => {})",
 }
 `;
 
-exports[`#230 - acorn.parse - async function () {} 1`] = `
-Object {
-  "args": Array [],
-  "body": "",
-  "defaults": Object {},
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "",
-  "value": "(async function () {})",
-}
-`;
-
-exports[`#231 - acorn.parse - async function (a = (true, false)) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "false",
-  },
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "(async function (a = (true, false)) {})",
-}
-`;
-
-exports[`#231 - acorn.parse - async function (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
+exports[`#244 - acorn.parse - async function (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -9106,6 +5630,7 @@ Object {
     "cb": undefined,
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": true,
@@ -9119,29 +5644,7 @@ Object {
 }
 `;
 
-exports[`#232 - acorn.parse - async function (a = (true, null)) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "null",
-  },
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "(async function (a = (true, null)) {})",
-}
-`;
-
-exports[`#232 - acorn.parse - async function (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
+exports[`#245 - acorn.parse - async function (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
 Object {
   "args": Array [
     "b",
@@ -9154,6 +5657,7 @@ Object {
     "callback": undefined,
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": true,
@@ -9167,29 +5671,7 @@ Object {
 }
 `;
 
-exports[`#233 - acorn.parse - async function (a = (true, "bar")) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "\\"bar\\"",
-  },
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "(async function (a = (true, \\"bar\\")) {})",
-}
-`;
-
-exports[`#233 - acorn.parse - async function (c) {return c * 3} 1`] = `
+exports[`#246 - acorn.parse - async function (c) {return c * 3} 1`] = `
 Object {
   "args": Array [
     "c",
@@ -9198,6 +5680,7 @@ Object {
   "defaults": Object {
     "c": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": true,
@@ -9211,7 +5694,7 @@ Object {
 }
 `;
 
-exports[`#234 - acorn.parse - async function (...restArgs) {return 321} 1`] = `
+exports[`#247 - acorn.parse - async function (...restArgs) {return 321} 1`] = `
 Object {
   "args": Array [
     "restArgs",
@@ -9220,6 +5703,7 @@ Object {
   "defaults": Object {
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": true,
@@ -9233,35 +5717,12 @@ Object {
 }
 `;
 
-exports[`#234 - acorn.parse - async function (a, b = (i++, true)) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-    "b",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": undefined,
-    "b": "true",
-  },
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a, b",
-  "value": "(async function (a, b = (i++, true)) {})",
-}
-`;
-
-exports[`#235 - acorn.parse - async function () {} 1`] = `
+exports[`#248 - acorn.parse - async function () {} 1`] = `
 Object {
   "args": Array [],
   "body": "",
   "defaults": Object {},
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": true,
@@ -9275,29 +5736,7 @@ Object {
 }
 `;
 
-exports[`#235 - acorn.parse - async function (a = 1) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "1",
-  },
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "(async function (a = 1) {})",
-}
-`;
-
-exports[`#236 - acorn.parse - async function (a = (true, false)) {} 1`] = `
+exports[`#249 - acorn.parse - async function (a = (true, false)) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -9306,6 +5745,7 @@ Object {
   "defaults": Object {
     "a": "false",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": true,
@@ -9319,33 +5759,7 @@ Object {
 }
 `;
 
-exports[`#236 - acorn.parse - async function namedFn (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
-Object {
-  "args": Array [
-    "a",
-    "cb",
-    "restArgs",
-  ],
-  "body": "return a * 3",
-  "defaults": Object {
-    "a": "{foo: \\"ba)r\\", baz: 123}",
-    "cb": undefined,
-    "restArgs": undefined,
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "a, cb, restArgs",
-  "value": "(async function namedFn (a = {foo: \\"ba)r\\", baz: 123}, cb, ...restArgs) {return a * 3})",
-}
-`;
-
-exports[`#237 - acorn.parse - async function (a = (true, null)) {} 1`] = `
+exports[`#250 - acorn.parse - async function (a = (true, null)) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -9354,6 +5768,7 @@ Object {
   "defaults": Object {
     "a": "null",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": true,
@@ -9367,33 +5782,7 @@ Object {
 }
 `;
 
-exports[`#237 - acorn.parse - async function namedFn (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
-Object {
-  "args": Array [
-    "b",
-    "callback",
-    "restArgs",
-  ],
-  "body": "callback(null, b + 3)",
-  "defaults": Object {
-    "b": undefined,
-    "callback": undefined,
-    "restArgs": undefined,
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "b, callback, restArgs",
-  "value": "(async function namedFn (b, callback, ...restArgs) {callback(null, b + 3)})",
-}
-`;
-
-exports[`#238 - acorn.parse - async function (a = (true, "bar")) {} 1`] = `
+exports[`#251 - acorn.parse - async function (a = (true, "bar")) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -9402,6 +5791,7 @@ Object {
   "defaults": Object {
     "a": "\\"bar\\"",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": true,
@@ -9415,29 +5805,7 @@ Object {
 }
 `;
 
-exports[`#238 - acorn.parse - async function namedFn (c) {return c * 3} 1`] = `
-Object {
-  "args": Array [
-    "c",
-  ],
-  "body": "return c * 3",
-  "defaults": Object {
-    "c": undefined,
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "c",
-  "value": "(async function namedFn (c) {return c * 3})",
-}
-`;
-
-exports[`#239 - acorn.parse - async function (a, b = (i++, true)) {} 1`] = `
+exports[`#252 - acorn.parse - async function (a, b = (i++, true)) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -9448,6 +5816,7 @@ Object {
     "a": undefined,
     "b": "true",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": true,
@@ -9461,29 +5830,7 @@ Object {
 }
 `;
 
-exports[`#239 - acorn.parse - async function namedFn (...restArgs) {return 321} 1`] = `
-Object {
-  "args": Array [
-    "restArgs",
-  ],
-  "body": "return 321",
-  "defaults": Object {
-    "restArgs": undefined,
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "restArgs",
-  "value": "(async function namedFn (...restArgs) {return 321})",
-}
-`;
-
-exports[`#240 - acorn.parse - async function (a = 1) {} 1`] = `
+exports[`#253 - acorn.parse - async function (a = 1) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -9492,6 +5839,7 @@ Object {
   "defaults": Object {
     "a": "1",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": true,
@@ -9505,25 +5853,33 @@ Object {
 }
 `;
 
-exports[`#240 - acorn.parse - async function namedFn () {} 1`] = `
+exports[`#254 - acorn.parse - async function ({x, y}) {} 1`] = `
 Object {
-  "args": Array [],
+  "args": Array [
+    false,
+  ],
   "body": "",
-  "defaults": Object {},
-  "isAnonymous": false,
+  "defaults": Object {
+    "false": undefined,
+  },
+  "destructuredArgs": Array [
+    "x",
+    "y",
+  ],
+  "isAnonymous": true,
   "isArrow": false,
   "isAsync": true,
   "isExpression": false,
   "isGenerator": false,
-  "isNamed": true,
+  "isNamed": false,
   "isValid": true,
-  "name": "namedFn",
-  "params": "",
-  "value": "(async function namedFn () {})",
+  "name": null,
+  "params": "false",
+  "value": "(async function ({x, y}) {})",
 }
 `;
 
-exports[`#241 - acorn.parse - async function namedFn (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
+exports[`#255 - acorn.parse - async function namedFn (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -9536,6 +5892,7 @@ Object {
     "cb": undefined,
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": true,
@@ -9549,29 +5906,7 @@ Object {
 }
 `;
 
-exports[`#241 - acorn.parse - async function namedFn(a = (true, false)) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "false",
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "a",
-  "value": "(async function namedFn(a = (true, false)) {})",
-}
-`;
-
-exports[`#242 - acorn.parse - async function namedFn (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
+exports[`#256 - acorn.parse - async function namedFn (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
 Object {
   "args": Array [
     "b",
@@ -9584,6 +5919,7 @@ Object {
     "callback": undefined,
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": true,
@@ -9597,29 +5933,7 @@ Object {
 }
 `;
 
-exports[`#242 - acorn.parse - async function namedFn(a = (true, null)) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "null",
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "a",
-  "value": "(async function namedFn(a = (true, null)) {})",
-}
-`;
-
-exports[`#243 - acorn.parse - async function namedFn (c) {return c * 3} 1`] = `
+exports[`#257 - acorn.parse - async function namedFn (c) {return c * 3} 1`] = `
 Object {
   "args": Array [
     "c",
@@ -9628,6 +5942,7 @@ Object {
   "defaults": Object {
     "c": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": true,
@@ -9641,29 +5956,7 @@ Object {
 }
 `;
 
-exports[`#243 - acorn.parse - async function namedFn(a = (true, "bar")) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "\\"bar\\"",
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "a",
-  "value": "(async function namedFn(a = (true, \\"bar\\")) {})",
-}
-`;
-
-exports[`#244 - acorn.parse - async function namedFn (...restArgs) {return 321} 1`] = `
+exports[`#258 - acorn.parse - async function namedFn (...restArgs) {return 321} 1`] = `
 Object {
   "args": Array [
     "restArgs",
@@ -9672,6 +5965,7 @@ Object {
   "defaults": Object {
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": true,
@@ -9685,35 +5979,12 @@ Object {
 }
 `;
 
-exports[`#244 - acorn.parse - async function namedFn(a, b = (i++, true)) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-    "b",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": undefined,
-    "b": "true",
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "a, b",
-  "value": "(async function namedFn(a, b = (i++, true)) {})",
-}
-`;
-
-exports[`#245 - acorn.parse - async function namedFn () {} 1`] = `
+exports[`#259 - acorn.parse - async function namedFn () {} 1`] = `
 Object {
   "args": Array [],
   "body": "",
   "defaults": Object {},
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": true,
@@ -9727,55 +5998,7 @@ Object {
 }
 `;
 
-exports[`#245 - acorn.parse - async function namedFn(a = 1) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "1",
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "a",
-  "value": "(async function namedFn(a = 1) {})",
-}
-`;
-
-exports[`#246 - acorn.parse - async (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) => {return a * 3} 1`] = `
-Object {
-  "args": Array [
-    "a",
-    "cb",
-    "restArgs",
-  ],
-  "body": "return a * 3",
-  "defaults": Object {
-    "a": "{foo: \\"ba)r\\", baz: 123}",
-    "cb": undefined,
-    "restArgs": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a, cb, restArgs",
-  "value": "(async (a = {foo: \\"ba)r\\", baz: 123}, cb, ...restArgs) => {return a * 3})",
-}
-`;
-
-exports[`#246 - acorn.parse - async function namedFn(a = (true, false)) {} 1`] = `
+exports[`#260 - acorn.parse - async function namedFn(a = (true, false)) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -9784,6 +6007,7 @@ Object {
   "defaults": Object {
     "a": "false",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": true,
@@ -9797,33 +6021,7 @@ Object {
 }
 `;
 
-exports[`#247 - acorn.parse - async (b, callback, ...restArgs) => {callback(null, b + 3)} 1`] = `
-Object {
-  "args": Array [
-    "b",
-    "callback",
-    "restArgs",
-  ],
-  "body": "callback(null, b + 3)",
-  "defaults": Object {
-    "b": undefined,
-    "callback": undefined,
-    "restArgs": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "b, callback, restArgs",
-  "value": "(async (b, callback, ...restArgs) => {callback(null, b + 3)})",
-}
-`;
-
-exports[`#247 - acorn.parse - async function namedFn(a = (true, null)) {} 1`] = `
+exports[`#261 - acorn.parse - async function namedFn(a = (true, null)) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -9832,6 +6030,7 @@ Object {
   "defaults": Object {
     "a": "null",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": true,
@@ -9845,29 +6044,7 @@ Object {
 }
 `;
 
-exports[`#248 - acorn.parse - async (c) => {return c * 3} 1`] = `
-Object {
-  "args": Array [
-    "c",
-  ],
-  "body": "return c * 3",
-  "defaults": Object {
-    "c": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "c",
-  "value": "(async (c) => {return c * 3})",
-}
-`;
-
-exports[`#248 - acorn.parse - async function namedFn(a = (true, "bar")) {} 1`] = `
+exports[`#262 - acorn.parse - async function namedFn(a = (true, "bar")) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -9876,6 +6053,7 @@ Object {
   "defaults": Object {
     "a": "\\"bar\\"",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": true,
@@ -9889,29 +6067,7 @@ Object {
 }
 `;
 
-exports[`#249 - acorn.parse - async (...restArgs) => {return 321} 1`] = `
-Object {
-  "args": Array [
-    "restArgs",
-  ],
-  "body": "return 321",
-  "defaults": Object {
-    "restArgs": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "restArgs",
-  "value": "(async (...restArgs) => {return 321})",
-}
-`;
-
-exports[`#249 - acorn.parse - async function namedFn(a, b = (i++, true)) {} 1`] = `
+exports[`#263 - acorn.parse - async function namedFn(a, b = (i++, true)) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -9922,6 +6078,7 @@ Object {
     "a": undefined,
     "b": "true",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": true,
@@ -9935,25 +6092,7 @@ Object {
 }
 `;
 
-exports[`#250 - acorn.parse - async () => {} 1`] = `
-Object {
-  "args": Array [],
-  "body": "",
-  "defaults": Object {},
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "",
-  "value": "(async () => {})",
-}
-`;
-
-exports[`#250 - acorn.parse - async function namedFn(a = 1) {} 1`] = `
+exports[`#264 - acorn.parse - async function namedFn(a = 1) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -9962,6 +6101,7 @@ Object {
   "defaults": Object {
     "a": "1",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": true,
@@ -9975,29 +6115,33 @@ Object {
 }
 `;
 
-exports[`#251 - acorn.parse - async (a = (true, false)) => {} 1`] = `
+exports[`#265 - acorn.parse - async function namedFn({x, y}) {} 1`] = `
 Object {
   "args": Array [
-    "a",
+    false,
   ],
   "body": "",
   "defaults": Object {
-    "a": "false",
+    "false": undefined,
   },
-  "isAnonymous": true,
-  "isArrow": true,
+  "destructuredArgs": Array [
+    "x",
+    "y",
+  ],
+  "isAnonymous": false,
+  "isArrow": false,
   "isAsync": true,
   "isExpression": false,
   "isGenerator": false,
-  "isNamed": false,
+  "isNamed": true,
   "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "(async (a = (true, false)) => {})",
+  "name": "namedFn",
+  "params": "false",
+  "value": "(async function namedFn({x, y}) {})",
 }
 `;
 
-exports[`#251 - acorn.parse - async (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) => {return a * 3} 1`] = `
+exports[`#266 - acorn.parse - async (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) => {return a * 3} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -10010,6 +6154,7 @@ Object {
     "cb": undefined,
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -10023,29 +6168,7 @@ Object {
 }
 `;
 
-exports[`#252 - acorn.parse - async (a = (true, null)) => {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "null",
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "(async (a = (true, null)) => {})",
-}
-`;
-
-exports[`#252 - acorn.parse - async (b, callback, ...restArgs) => {callback(null, b + 3)} 1`] = `
+exports[`#267 - acorn.parse - async (b, callback, ...restArgs) => {callback(null, b + 3)} 1`] = `
 Object {
   "args": Array [
     "b",
@@ -10058,6 +6181,7 @@ Object {
     "callback": undefined,
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -10071,29 +6195,7 @@ Object {
 }
 `;
 
-exports[`#253 - acorn.parse - async (a = (true, "bar")) => {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "\\"bar\\"",
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "(async (a = (true, \\"bar\\")) => {})",
-}
-`;
-
-exports[`#253 - acorn.parse - async (c) => {return c * 3} 1`] = `
+exports[`#268 - acorn.parse - async (c) => {return c * 3} 1`] = `
 Object {
   "args": Array [
     "c",
@@ -10102,6 +6204,7 @@ Object {
   "defaults": Object {
     "c": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -10115,7 +6218,7 @@ Object {
 }
 `;
 
-exports[`#254 - acorn.parse - async (...restArgs) => {return 321} 1`] = `
+exports[`#269 - acorn.parse - async (...restArgs) => {return 321} 1`] = `
 Object {
   "args": Array [
     "restArgs",
@@ -10124,6 +6227,7 @@ Object {
   "defaults": Object {
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -10137,35 +6241,12 @@ Object {
 }
 `;
 
-exports[`#254 - acorn.parse - async (a, b = (i++, true)) => {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-    "b",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": undefined,
-    "b": "true",
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a, b",
-  "value": "(async (a, b = (i++, true)) => {})",
-}
-`;
-
-exports[`#255 - acorn.parse - async () => {} 1`] = `
+exports[`#270 - acorn.parse - async () => {} 1`] = `
 Object {
   "args": Array [],
   "body": "",
   "defaults": Object {},
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -10179,29 +6260,7 @@ Object {
 }
 `;
 
-exports[`#255 - acorn.parse - async (a = 1) => {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "1",
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "(async (a = 1) => {})",
-}
-`;
-
-exports[`#256 - acorn.parse - async (a = (true, false)) => {} 1`] = `
+exports[`#271 - acorn.parse - async (a = (true, false)) => {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -10210,6 +6269,7 @@ Object {
   "defaults": Object {
     "a": "false",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -10223,29 +6283,7 @@ Object {
 }
 `;
 
-exports[`#256 - acorn.parse - async (a) => a * 3 * a 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "a * 3 * a",
-  "defaults": Object {
-    "a": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": true,
-  "isExpression": true,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "(async (a) => a * 3 * a)",
-}
-`;
-
-exports[`#257 - acorn.parse - async (a = (true, null)) => {} 1`] = `
+exports[`#272 - acorn.parse - async (a = (true, null)) => {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -10254,6 +6292,7 @@ Object {
   "defaults": Object {
     "a": "null",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -10267,29 +6306,7 @@ Object {
 }
 `;
 
-exports[`#257 - acorn.parse - async d => d * 355 * d 1`] = `
-Object {
-  "args": Array [
-    "d",
-  ],
-  "body": "d * 355 * d",
-  "defaults": Object {
-    "d": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": true,
-  "isExpression": true,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "d",
-  "value": "(async d => d * 355 * d)",
-}
-`;
-
-exports[`#258 - acorn.parse - async (a = (true, "bar")) => {} 1`] = `
+exports[`#273 - acorn.parse - async (a = (true, "bar")) => {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -10298,6 +6315,7 @@ Object {
   "defaults": Object {
     "a": "\\"bar\\"",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -10311,29 +6329,7 @@ Object {
 }
 `;
 
-exports[`#258 - acorn.parse - async e => {return e + 5235 / e} 1`] = `
-Object {
-  "args": Array [
-    "e",
-  ],
-  "body": "return e + 5235 / e",
-  "defaults": Object {
-    "e": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "e",
-  "value": "(async e => {return e + 5235 / e})",
-}
-`;
-
-exports[`#259 - acorn.parse - async (a, b = (i++, true)) => {} 1`] = `
+exports[`#274 - acorn.parse - async (a, b = (i++, true)) => {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -10344,6 +6340,7 @@ Object {
     "a": undefined,
     "b": "true",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -10357,31 +6354,7 @@ Object {
 }
 `;
 
-exports[`#259 - acorn.parse - async (a, b) => a + 3 + b 1`] = `
-Object {
-  "args": Array [
-    "a",
-    "b",
-  ],
-  "body": "a + 3 + b",
-  "defaults": Object {
-    "a": undefined,
-    "b": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": true,
-  "isExpression": true,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a, b",
-  "value": "(async (a, b) => a + 3 + b)",
-}
-`;
-
-exports[`#260 - acorn.parse - async (a = 1) => {} 1`] = `
+exports[`#275 - acorn.parse - async (a = 1) => {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -10390,6 +6363,7 @@ Object {
   "defaults": Object {
     "a": "1",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -10403,33 +6377,7 @@ Object {
 }
 `;
 
-exports[`#260 - acorn.parse - async (x, y, ...restArgs) => console.log({ value: x * y }) 1`] = `
-Object {
-  "args": Array [
-    "x",
-    "y",
-    "restArgs",
-  ],
-  "body": "console.log({ value: x * y })",
-  "defaults": Object {
-    "restArgs": undefined,
-    "x": undefined,
-    "y": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": true,
-  "isExpression": true,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "x, y, restArgs",
-  "value": "(async (x, y, ...restArgs) => console.log({ value: x * y }))",
-}
-`;
-
-exports[`#261 - acorn.parse - async (a) => a * 3 * a 1`] = `
+exports[`#276 - acorn.parse - async (a) => a * 3 * a 1`] = `
 Object {
   "args": Array [
     "a",
@@ -10438,6 +6386,7 @@ Object {
   "defaults": Object {
     "a": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -10451,25 +6400,7 @@ Object {
 }
 `;
 
-exports[`#261 - acorn.parse - should return object with default values when invalid 1`] = `
-Object {
-  "args": Array [],
-  "body": "",
-  "defaults": Object {},
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": false,
-  "name": null,
-  "params": "",
-  "value": "",
-}
-`;
-
-exports[`#262 - acorn.parse - async d => d * 355 * d 1`] = `
+exports[`#277 - acorn.parse - async d => d * 355 * d 1`] = `
 Object {
   "args": Array [
     "d",
@@ -10478,6 +6409,7 @@ Object {
   "defaults": Object {
     "d": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -10491,25 +6423,7 @@ Object {
 }
 `;
 
-exports[`#262 - acorn.parse - should have '.isValid' and few '.is*'' hidden properties 1`] = `
-Object {
-  "args": Array [],
-  "body": "",
-  "defaults": Object {},
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": false,
-  "name": null,
-  "params": "",
-  "value": "",
-}
-`;
-
-exports[`#263 - acorn.parse - async e => {return e + 5235 / e} 1`] = `
+exports[`#278 - acorn.parse - async e => {return e + 5235 / e} 1`] = `
 Object {
   "args": Array [
     "e",
@@ -10518,6 +6432,7 @@ Object {
   "defaults": Object {
     "e": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -10531,7 +6446,7 @@ Object {
 }
 `;
 
-exports[`#264 - acorn.parse - async (a, b) => a + 3 + b 1`] = `
+exports[`#279 - acorn.parse - async (a, b) => a + 3 + b 1`] = `
 Object {
   "args": Array [
     "a",
@@ -10542,6 +6457,7 @@ Object {
     "a": undefined,
     "b": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -10555,7 +6471,7 @@ Object {
 }
 `;
 
-exports[`#265 - acorn.parse - async (x, y, ...restArgs) => console.log({ value: x * y }) 1`] = `
+exports[`#280 - acorn.parse - async (x, y, ...restArgs) => console.log({ value: x * y }) 1`] = `
 Object {
   "args": Array [
     "x",
@@ -10568,6 +6484,7 @@ Object {
     "x": undefined,
     "y": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -10581,14 +6498,19 @@ Object {
 }
 `;
 
-exports[`#266 - acorn.parse - async ({x, y}) => {} 1`] = `
+exports[`#281 - acorn.parse - async ({x, y}) => {} 1`] = `
 Object {
   "args": Array [
+    false,
+  ],
+  "body": "",
+  "defaults": Object {
+    "false": undefined,
+  },
+  "destructuredArgs": Array [
     "x",
     "y",
   ],
-  "body": "",
-  "defaults": Object {},
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -10597,12 +6519,12 @@ Object {
   "isNamed": false,
   "isValid": true,
   "name": null,
-  "params": "x, y",
+  "params": "false",
   "value": "(async ({x, y}) => {})",
 }
 `;
 
-exports[`#267 - acorn.parse - should return object with default values when invalid 1`] = `
+exports[`#282 - acorn.parse - should return object with default values when invalid 1`] = `
 Object {
   "args": Array [],
   "body": "",
@@ -10620,115 +6542,7 @@ Object {
 }
 `;
 
-exports[`#267 - acorn.parse - should work for object methods 1`] = `
-Object {
-  "args": Array [
-    "a",
-    "b",
-    "c",
-  ],
-  "body": "
-        return 123;
-      ",
-  "defaults": Object {
-    "a": undefined,
-    "b": undefined,
-    "c": undefined,
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "foo",
-  "params": "a, b, c",
-  "value": "({ foo(a, b, c) {
-        return 123;
-      } })",
-}
-`;
-
-exports[`#267 - acorn.parse - should work for object methods 2`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "
-        return () => a;
-      ",
-  "defaults": Object {
-    "a": undefined,
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "bar",
-  "params": "a",
-  "value": "({ bar(a) {
-        return () => a;
-      } })",
-}
-`;
-
-exports[`#267 - acorn.parse - should work for object methods 3`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "
-        return yield a * 321;
-      ",
-  "defaults": Object {
-    "a": undefined,
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": true,
-  "isNamed": true,
-  "isValid": true,
-  "name": "gen",
-  "params": "a",
-  "value": "({ *gen(a) {
-        return yield a * 321;
-      } })",
-}
-`;
-
-exports[`#267 - acorn.parse - should work for object methods 4`] = `
-Object {
-  "args": Array [
-    "a",
-    "cb",
-    "restArgs",
-  ],
-  "body": " return a * 3 ",
-  "defaults": Object {
-    "a": "{foo: 'ba)r', baz: 123}",
-    "cb": undefined,
-    "restArgs": undefined,
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "a, cb, restArgs",
-  "value": "({ namedFn (a = {foo: 'ba)r', baz: 123}, cb, ...restArgs) { return a * 3 } })",
-}
-`;
-
-exports[`#268 - acorn.parse - should have '.isValid' and few '.is*'' hidden properties 1`] = `
+exports[`#283 - acorn.parse - should have '.isValid' and few '.is*'' hidden properties 1`] = `
 Object {
   "args": Array [],
   "body": "",
@@ -10746,81 +6560,7 @@ Object {
 }
 `;
 
-exports[`#271 - acorn loose - function (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
-Object {
-  "args": Array [
-    "a",
-    "cb",
-    "restArgs",
-  ],
-  "body": "return a * 3",
-  "defaults": Object {
-    "a": "{foo: \\"ba)r\\", baz: 123}",
-    "cb": undefined,
-    "restArgs": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a, cb, restArgs",
-  "value": "(function (a = {foo: \\"ba)r\\", baz: 123}, cb, ...restArgs) {return a * 3})",
-}
-`;
-
-exports[`#272 - acorn loose - function (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
-Object {
-  "args": Array [
-    "b",
-    "callback",
-    "restArgs",
-  ],
-  "body": "callback(null, b + 3)",
-  "defaults": Object {
-    "b": undefined,
-    "callback": undefined,
-    "restArgs": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "b, callback, restArgs",
-  "value": "(function (b, callback, ...restArgs) {callback(null, b + 3)})",
-}
-`;
-
-exports[`#273 - acorn loose - function (c) {return c * 3} 1`] = `
-Object {
-  "args": Array [
-    "c",
-  ],
-  "body": "return c * 3",
-  "defaults": Object {
-    "c": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "c",
-  "value": "(function (c) {return c * 3})",
-}
-`;
-
-exports[`#273 - acorn.parse - should work for object methods 1`] = `
+exports[`#288 - acorn.parse - should work for object methods 1`] = `
 Object {
   "args": Array [
     "a",
@@ -10835,6 +6575,7 @@ Object {
     "b": undefined,
     "c": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -10850,7 +6591,7 @@ Object {
 }
 `;
 
-exports[`#273 - acorn.parse - should work for object methods 2`] = `
+exports[`#288 - acorn.parse - should work for object methods 2`] = `
 Object {
   "args": Array [
     "a",
@@ -10861,6 +6602,7 @@ Object {
   "defaults": Object {
     "a": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -10876,7 +6618,7 @@ Object {
 }
 `;
 
-exports[`#273 - acorn.parse - should work for object methods 3`] = `
+exports[`#288 - acorn.parse - should work for object methods 3`] = `
 Object {
   "args": Array [
     "a",
@@ -10887,6 +6629,7 @@ Object {
   "defaults": Object {
     "a": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -10902,7 +6645,7 @@ Object {
 }
 `;
 
-exports[`#273 - acorn.parse - should work for object methods 4`] = `
+exports[`#288 - acorn.parse - should work for object methods 4`] = `
 Object {
   "args": Array [
     "a",
@@ -10915,6 +6658,7 @@ Object {
     "cb": undefined,
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -10928,91 +6672,7 @@ Object {
 }
 `;
 
-exports[`#274 - acorn loose - function (...restArgs) {return 321} 1`] = `
-Object {
-  "args": Array [
-    "restArgs",
-  ],
-  "body": "return 321",
-  "defaults": Object {
-    "restArgs": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "restArgs",
-  "value": "(function (...restArgs) {return 321})",
-}
-`;
-
-exports[`#275 - acorn loose - function () {} 1`] = `
-Object {
-  "args": Array [],
-  "body": "",
-  "defaults": Object {},
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "",
-  "value": "(function () {})",
-}
-`;
-
-exports[`#276 - acorn loose - function (a = (true, false)) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "false",
-  },
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "(function (a = (true, false)) {})",
-}
-`;
-
-exports[`#277 - acorn loose - function (a = (true, null)) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "null",
-  },
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "(function (a = (true, null)) {})",
-}
-`;
-
-exports[`#277 - acorn loose - function (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
+exports[`#292 - acorn loose - function (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -11025,6 +6685,7 @@ Object {
     "cb": undefined,
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": false,
@@ -11038,29 +6699,7 @@ Object {
 }
 `;
 
-exports[`#278 - acorn loose - function (a = (true, "bar")) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "\\"bar\\"",
-  },
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "(function (a = (true, \\"bar\\")) {})",
-}
-`;
-
-exports[`#278 - acorn loose - function (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
+exports[`#293 - acorn loose - function (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
 Object {
   "args": Array [
     "b",
@@ -11073,6 +6712,7 @@ Object {
     "callback": undefined,
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": false,
@@ -11086,31 +6726,7 @@ Object {
 }
 `;
 
-exports[`#279 - acorn loose - function (a, b = (i++, true)) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-    "b",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": undefined,
-    "b": "true",
-  },
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a, b",
-  "value": "(function (a, b = (i++, true)) {})",
-}
-`;
-
-exports[`#279 - acorn loose - function (c) {return c * 3} 1`] = `
+exports[`#294 - acorn loose - function (c) {return c * 3} 1`] = `
 Object {
   "args": Array [
     "c",
@@ -11119,6 +6735,7 @@ Object {
   "defaults": Object {
     "c": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": false,
@@ -11132,7 +6749,7 @@ Object {
 }
 `;
 
-exports[`#280 - acorn loose - function (...restArgs) {return 321} 1`] = `
+exports[`#295 - acorn loose - function (...restArgs) {return 321} 1`] = `
 Object {
   "args": Array [
     "restArgs",
@@ -11141,6 +6758,7 @@ Object {
   "defaults": Object {
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": false,
@@ -11154,33 +6772,12 @@ Object {
 }
 `;
 
-exports[`#280 - acorn loose - function (a = 1) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "1",
-  },
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "(function (a = 1) {})",
-}
-`;
-
-exports[`#281 - acorn loose - function () {} 1`] = `
+exports[`#296 - acorn loose - function () {} 1`] = `
 Object {
   "args": Array [],
   "body": "",
   "defaults": Object {},
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": false,
@@ -11194,33 +6791,7 @@ Object {
 }
 `;
 
-exports[`#281 - acorn loose - function namedFn (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
-Object {
-  "args": Array [
-    "a",
-    "cb",
-    "restArgs",
-  ],
-  "body": "return a * 3",
-  "defaults": Object {
-    "a": "{foo: \\"ba)r\\", baz: 123}",
-    "cb": undefined,
-    "restArgs": undefined,
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "a, cb, restArgs",
-  "value": "(function namedFn (a = {foo: \\"ba)r\\", baz: 123}, cb, ...restArgs) {return a * 3})",
-}
-`;
-
-exports[`#282 - acorn loose - function (a = (true, false)) {} 1`] = `
+exports[`#297 - acorn loose - function (a = (true, false)) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -11229,6 +6800,7 @@ Object {
   "defaults": Object {
     "a": "false",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": false,
@@ -11242,33 +6814,7 @@ Object {
 }
 `;
 
-exports[`#282 - acorn loose - function namedFn (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
-Object {
-  "args": Array [
-    "b",
-    "callback",
-    "restArgs",
-  ],
-  "body": "callback(null, b + 3)",
-  "defaults": Object {
-    "b": undefined,
-    "callback": undefined,
-    "restArgs": undefined,
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "b, callback, restArgs",
-  "value": "(function namedFn (b, callback, ...restArgs) {callback(null, b + 3)})",
-}
-`;
-
-exports[`#283 - acorn loose - function (a = (true, null)) {} 1`] = `
+exports[`#298 - acorn loose - function (a = (true, null)) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -11277,6 +6823,7 @@ Object {
   "defaults": Object {
     "a": "null",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": false,
@@ -11290,29 +6837,7 @@ Object {
 }
 `;
 
-exports[`#283 - acorn loose - function namedFn (c) {return c * 3} 1`] = `
-Object {
-  "args": Array [
-    "c",
-  ],
-  "body": "return c * 3",
-  "defaults": Object {
-    "c": undefined,
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "c",
-  "value": "(function namedFn (c) {return c * 3})",
-}
-`;
-
-exports[`#284 - acorn loose - function (a = (true, "bar")) {} 1`] = `
+exports[`#299 - acorn loose - function (a = (true, "bar")) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -11321,6 +6846,7 @@ Object {
   "defaults": Object {
     "a": "\\"bar\\"",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": false,
@@ -11334,29 +6860,7 @@ Object {
 }
 `;
 
-exports[`#284 - acorn loose - function namedFn (...restArgs) {return 321} 1`] = `
-Object {
-  "args": Array [
-    "restArgs",
-  ],
-  "body": "return 321",
-  "defaults": Object {
-    "restArgs": undefined,
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "restArgs",
-  "value": "(function namedFn (...restArgs) {return 321})",
-}
-`;
-
-exports[`#285 - acorn loose - function (a, b = (i++, true)) {} 1`] = `
+exports[`#300 - acorn loose - function (a, b = (i++, true)) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -11367,6 +6871,7 @@ Object {
     "a": undefined,
     "b": "true",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": false,
@@ -11380,25 +6885,7 @@ Object {
 }
 `;
 
-exports[`#285 - acorn loose - function namedFn () {} 1`] = `
-Object {
-  "args": Array [],
-  "body": "",
-  "defaults": Object {},
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "",
-  "value": "(function namedFn () {})",
-}
-`;
-
-exports[`#286 - acorn loose - function (a = 1) {} 1`] = `
+exports[`#301 - acorn loose - function (a = 1) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -11407,6 +6894,7 @@ Object {
   "defaults": Object {
     "a": "1",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": false,
@@ -11420,29 +6908,33 @@ Object {
 }
 `;
 
-exports[`#286 - acorn loose - function namedFn(a = (true, false)) {} 1`] = `
+exports[`#302 - acorn loose - function ({x, y}) {} 1`] = `
 Object {
   "args": Array [
-    "a",
+    false,
   ],
   "body": "",
   "defaults": Object {
-    "a": "false",
+    "false": undefined,
   },
-  "isAnonymous": false,
+  "destructuredArgs": Array [
+    "x",
+    "y",
+  ],
+  "isAnonymous": true,
   "isArrow": false,
   "isAsync": false,
   "isExpression": false,
   "isGenerator": false,
-  "isNamed": true,
+  "isNamed": false,
   "isValid": true,
-  "name": "namedFn",
-  "params": "a",
-  "value": "(function namedFn(a = (true, false)) {})",
+  "name": null,
+  "params": "false",
+  "value": "(function ({x, y}) {})",
 }
 `;
 
-exports[`#287 - acorn loose - function namedFn (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
+exports[`#303 - acorn loose - function namedFn (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -11455,6 +6947,7 @@ Object {
     "cb": undefined,
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -11468,29 +6961,7 @@ Object {
 }
 `;
 
-exports[`#287 - acorn loose - function namedFn(a = (true, null)) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "null",
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "a",
-  "value": "(function namedFn(a = (true, null)) {})",
-}
-`;
-
-exports[`#288 - acorn loose - function namedFn (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
+exports[`#304 - acorn loose - function namedFn (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
 Object {
   "args": Array [
     "b",
@@ -11503,6 +6974,7 @@ Object {
     "callback": undefined,
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -11516,29 +6988,7 @@ Object {
 }
 `;
 
-exports[`#288 - acorn loose - function namedFn(a = (true, "bar")) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "\\"bar\\"",
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "a",
-  "value": "(function namedFn(a = (true, \\"bar\\")) {})",
-}
-`;
-
-exports[`#289 - acorn loose - function namedFn (c) {return c * 3} 1`] = `
+exports[`#305 - acorn loose - function namedFn (c) {return c * 3} 1`] = `
 Object {
   "args": Array [
     "c",
@@ -11547,6 +6997,7 @@ Object {
   "defaults": Object {
     "c": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -11560,31 +7011,7 @@ Object {
 }
 `;
 
-exports[`#289 - acorn loose - function namedFn(a, b = (i++, true)) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-    "b",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": undefined,
-    "b": "true",
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "a, b",
-  "value": "(function namedFn(a, b = (i++, true)) {})",
-}
-`;
-
-exports[`#290 - acorn loose - function namedFn (...restArgs) {return 321} 1`] = `
+exports[`#306 - acorn loose - function namedFn (...restArgs) {return 321} 1`] = `
 Object {
   "args": Array [
     "restArgs",
@@ -11593,6 +7020,7 @@ Object {
   "defaults": Object {
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -11606,59 +7034,12 @@ Object {
 }
 `;
 
-exports[`#290 - acorn loose - function namedFn(a = 1) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "1",
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "a",
-  "value": "(function namedFn(a = 1) {})",
-}
-`;
-
-exports[`#291 - acorn loose - function * namedFn (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
-Object {
-  "args": Array [
-    "a",
-    "cb",
-    "restArgs",
-  ],
-  "body": "return a * 3",
-  "defaults": Object {
-    "a": "{foo: \\"ba)r\\", baz: 123}",
-    "cb": undefined,
-    "restArgs": undefined,
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": true,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "a, cb, restArgs",
-  "value": "(function * namedFn (a = {foo: \\"ba)r\\", baz: 123}, cb, ...restArgs) {return a * 3})",
-}
-`;
-
-exports[`#291 - acorn loose - function namedFn () {} 1`] = `
+exports[`#307 - acorn loose - function namedFn () {} 1`] = `
 Object {
   "args": Array [],
   "body": "",
   "defaults": Object {},
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -11672,33 +7053,7 @@ Object {
 }
 `;
 
-exports[`#292 - acorn loose - function * namedFn (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
-Object {
-  "args": Array [
-    "b",
-    "callback",
-    "restArgs",
-  ],
-  "body": "callback(null, b + 3)",
-  "defaults": Object {
-    "b": undefined,
-    "callback": undefined,
-    "restArgs": undefined,
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": true,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "b, callback, restArgs",
-  "value": "(function * namedFn (b, callback, ...restArgs) {callback(null, b + 3)})",
-}
-`;
-
-exports[`#292 - acorn loose - function namedFn(a = (true, false)) {} 1`] = `
+exports[`#308 - acorn loose - function namedFn(a = (true, false)) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -11707,6 +7062,7 @@ Object {
   "defaults": Object {
     "a": "false",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -11720,29 +7076,7 @@ Object {
 }
 `;
 
-exports[`#293 - acorn loose - function * namedFn (c) {return c * 3} 1`] = `
-Object {
-  "args": Array [
-    "c",
-  ],
-  "body": "return c * 3",
-  "defaults": Object {
-    "c": undefined,
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": true,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "c",
-  "value": "(function * namedFn (c) {return c * 3})",
-}
-`;
-
-exports[`#293 - acorn loose - function namedFn(a = (true, null)) {} 1`] = `
+exports[`#309 - acorn loose - function namedFn(a = (true, null)) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -11751,6 +7085,7 @@ Object {
   "defaults": Object {
     "a": "null",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -11764,29 +7099,7 @@ Object {
 }
 `;
 
-exports[`#294 - acorn loose - function * namedFn (...restArgs) {return 321} 1`] = `
-Object {
-  "args": Array [
-    "restArgs",
-  ],
-  "body": "return 321",
-  "defaults": Object {
-    "restArgs": undefined,
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": true,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "restArgs",
-  "value": "(function * namedFn (...restArgs) {return 321})",
-}
-`;
-
-exports[`#294 - acorn loose - function namedFn(a = (true, "bar")) {} 1`] = `
+exports[`#310 - acorn loose - function namedFn(a = (true, "bar")) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -11795,6 +7108,7 @@ Object {
   "defaults": Object {
     "a": "\\"bar\\"",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -11808,25 +7122,7 @@ Object {
 }
 `;
 
-exports[`#295 - acorn loose - function * namedFn () {} 1`] = `
-Object {
-  "args": Array [],
-  "body": "",
-  "defaults": Object {},
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": true,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "",
-  "value": "(function * namedFn () {})",
-}
-`;
-
-exports[`#295 - acorn loose - function namedFn(a, b = (i++, true)) {} 1`] = `
+exports[`#311 - acorn loose - function namedFn(a, b = (i++, true)) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -11837,6 +7133,7 @@ Object {
     "a": undefined,
     "b": "true",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -11850,29 +7147,7 @@ Object {
 }
 `;
 
-exports[`#296 - acorn loose - function * namedFn(a = (true, false)) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "false",
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": true,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "a",
-  "value": "(function * namedFn(a = (true, false)) {})",
-}
-`;
-
-exports[`#296 - acorn loose - function namedFn(a = 1) {} 1`] = `
+exports[`#312 - acorn loose - function namedFn(a = 1) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -11881,6 +7156,7 @@ Object {
   "defaults": Object {
     "a": "1",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -11894,7 +7170,33 @@ Object {
 }
 `;
 
-exports[`#297 - acorn loose - function * namedFn (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
+exports[`#313 - acorn loose - function namedFn({x, y}) {} 1`] = `
+Object {
+  "args": Array [
+    false,
+  ],
+  "body": "",
+  "defaults": Object {
+    "false": undefined,
+  },
+  "destructuredArgs": Array [
+    "x",
+    "y",
+  ],
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "false",
+  "value": "(function namedFn({x, y}) {})",
+}
+`;
+
+exports[`#314 - acorn loose - function * namedFn (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -11907,6 +7209,7 @@ Object {
     "cb": undefined,
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -11920,29 +7223,7 @@ Object {
 }
 `;
 
-exports[`#297 - acorn loose - function * namedFn(a = (true, null)) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "null",
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": true,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "a",
-  "value": "(function * namedFn(a = (true, null)) {})",
-}
-`;
-
-exports[`#298 - acorn loose - function * namedFn (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
+exports[`#315 - acorn loose - function * namedFn (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
 Object {
   "args": Array [
     "b",
@@ -11955,6 +7236,7 @@ Object {
     "callback": undefined,
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -11968,29 +7250,7 @@ Object {
 }
 `;
 
-exports[`#298 - acorn loose - function * namedFn(a = (true, "bar")) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "\\"bar\\"",
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": true,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "a",
-  "value": "(function * namedFn(a = (true, \\"bar\\")) {})",
-}
-`;
-
-exports[`#299 - acorn loose - function * namedFn (c) {return c * 3} 1`] = `
+exports[`#316 - acorn loose - function * namedFn (c) {return c * 3} 1`] = `
 Object {
   "args": Array [
     "c",
@@ -11999,6 +7259,7 @@ Object {
   "defaults": Object {
     "c": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -12012,31 +7273,7 @@ Object {
 }
 `;
 
-exports[`#299 - acorn loose - function * namedFn(a, b = (i++, true)) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-    "b",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": undefined,
-    "b": "true",
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": true,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "a, b",
-  "value": "(function * namedFn(a, b = (i++, true)) {})",
-}
-`;
-
-exports[`#300 - acorn loose - function * namedFn (...restArgs) {return 321} 1`] = `
+exports[`#317 - acorn loose - function * namedFn (...restArgs) {return 321} 1`] = `
 Object {
   "args": Array [
     "restArgs",
@@ -12045,6 +7282,7 @@ Object {
   "defaults": Object {
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -12058,59 +7296,12 @@ Object {
 }
 `;
 
-exports[`#300 - acorn loose - function * namedFn(a = 1) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "1",
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": true,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "a",
-  "value": "(function * namedFn(a = 1) {})",
-}
-`;
-
-exports[`#301 - acorn loose - (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) => {return a * 3} 1`] = `
-Object {
-  "args": Array [
-    "a",
-    "cb",
-    "restArgs",
-  ],
-  "body": "return a * 3",
-  "defaults": Object {
-    "a": "{foo: \\"ba)r\\", baz: 123}",
-    "cb": undefined,
-    "restArgs": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a, cb, restArgs",
-  "value": "((a = {foo: \\"ba)r\\", baz: 123}, cb, ...restArgs) => {return a * 3})",
-}
-`;
-
-exports[`#301 - acorn loose - function * namedFn () {} 1`] = `
+exports[`#318 - acorn loose - function * namedFn () {} 1`] = `
 Object {
   "args": Array [],
   "body": "",
   "defaults": Object {},
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -12124,33 +7315,7 @@ Object {
 }
 `;
 
-exports[`#302 - acorn loose - (b, callback, ...restArgs) => {callback(null, b + 3)} 1`] = `
-Object {
-  "args": Array [
-    "b",
-    "callback",
-    "restArgs",
-  ],
-  "body": "callback(null, b + 3)",
-  "defaults": Object {
-    "b": undefined,
-    "callback": undefined,
-    "restArgs": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "b, callback, restArgs",
-  "value": "((b, callback, ...restArgs) => {callback(null, b + 3)})",
-}
-`;
-
-exports[`#302 - acorn loose - function * namedFn(a = (true, false)) {} 1`] = `
+exports[`#319 - acorn loose - function * namedFn(a = (true, false)) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -12159,6 +7324,7 @@ Object {
   "defaults": Object {
     "a": "false",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -12172,29 +7338,7 @@ Object {
 }
 `;
 
-exports[`#303 - acorn loose - (c) => {return c * 3} 1`] = `
-Object {
-  "args": Array [
-    "c",
-  ],
-  "body": "return c * 3",
-  "defaults": Object {
-    "c": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "c",
-  "value": "((c) => {return c * 3})",
-}
-`;
-
-exports[`#303 - acorn loose - function * namedFn(a = (true, null)) {} 1`] = `
+exports[`#320 - acorn loose - function * namedFn(a = (true, null)) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -12203,6 +7347,7 @@ Object {
   "defaults": Object {
     "a": "null",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -12216,29 +7361,7 @@ Object {
 }
 `;
 
-exports[`#304 - acorn loose - (...restArgs) => {return 321} 1`] = `
-Object {
-  "args": Array [
-    "restArgs",
-  ],
-  "body": "return 321",
-  "defaults": Object {
-    "restArgs": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "restArgs",
-  "value": "((...restArgs) => {return 321})",
-}
-`;
-
-exports[`#304 - acorn loose - function * namedFn(a = (true, "bar")) {} 1`] = `
+exports[`#321 - acorn loose - function * namedFn(a = (true, "bar")) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -12247,6 +7370,7 @@ Object {
   "defaults": Object {
     "a": "\\"bar\\"",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -12260,25 +7384,7 @@ Object {
 }
 `;
 
-exports[`#305 - acorn loose - () => {} 1`] = `
-Object {
-  "args": Array [],
-  "body": "",
-  "defaults": Object {},
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "",
-  "value": "(() => {})",
-}
-`;
-
-exports[`#305 - acorn loose - function * namedFn(a, b = (i++, true)) {} 1`] = `
+exports[`#322 - acorn loose - function * namedFn(a, b = (i++, true)) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -12289,6 +7395,7 @@ Object {
     "a": undefined,
     "b": "true",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -12302,29 +7409,7 @@ Object {
 }
 `;
 
-exports[`#306 - acorn loose - (a = (true, false)) => {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "false",
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "((a = (true, false)) => {})",
-}
-`;
-
-exports[`#306 - acorn loose - function * namedFn(a = 1) {} 1`] = `
+exports[`#323 - acorn loose - function * namedFn(a = 1) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -12333,6 +7418,7 @@ Object {
   "defaults": Object {
     "a": "1",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -12346,29 +7432,33 @@ Object {
 }
 `;
 
-exports[`#307 - acorn loose - (a = (true, null)) => {} 1`] = `
+exports[`#324 - acorn loose - function * namedFn({x, y}) {} 1`] = `
 Object {
   "args": Array [
-    "a",
+    false,
   ],
   "body": "",
   "defaults": Object {
-    "a": "null",
+    "false": undefined,
   },
-  "isAnonymous": true,
-  "isArrow": true,
+  "destructuredArgs": Array [
+    "x",
+    "y",
+  ],
+  "isAnonymous": false,
+  "isArrow": false,
   "isAsync": false,
   "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
+  "isGenerator": true,
+  "isNamed": true,
   "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "((a = (true, null)) => {})",
+  "name": "namedFn",
+  "params": "false",
+  "value": "(function * namedFn({x, y}) {})",
 }
 `;
 
-exports[`#307 - acorn loose - (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) => {return a * 3} 1`] = `
+exports[`#325 - acorn loose - (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) => {return a * 3} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -12381,6 +7471,7 @@ Object {
     "cb": undefined,
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -12394,29 +7485,7 @@ Object {
 }
 `;
 
-exports[`#308 - acorn loose - (a = (true, "bar")) => {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "\\"bar\\"",
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "((a = (true, \\"bar\\")) => {})",
-}
-`;
-
-exports[`#308 - acorn loose - (b, callback, ...restArgs) => {callback(null, b + 3)} 1`] = `
+exports[`#326 - acorn loose - (b, callback, ...restArgs) => {callback(null, b + 3)} 1`] = `
 Object {
   "args": Array [
     "b",
@@ -12429,6 +7498,7 @@ Object {
     "callback": undefined,
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -12442,31 +7512,7 @@ Object {
 }
 `;
 
-exports[`#309 - acorn loose - (a, b = (i++, true)) => {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-    "b",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": undefined,
-    "b": "true",
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a, b",
-  "value": "((a, b = (i++, true)) => {})",
-}
-`;
-
-exports[`#309 - acorn loose - (c) => {return c * 3} 1`] = `
+exports[`#327 - acorn loose - (c) => {return c * 3} 1`] = `
 Object {
   "args": Array [
     "c",
@@ -12475,6 +7521,7 @@ Object {
   "defaults": Object {
     "c": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -12488,7 +7535,7 @@ Object {
 }
 `;
 
-exports[`#310 - acorn loose - (...restArgs) => {return 321} 1`] = `
+exports[`#328 - acorn loose - (...restArgs) => {return 321} 1`] = `
 Object {
   "args": Array [
     "restArgs",
@@ -12497,6 +7544,7 @@ Object {
   "defaults": Object {
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -12510,33 +7558,12 @@ Object {
 }
 `;
 
-exports[`#310 - acorn loose - (a = 1) => {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "1",
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "((a = 1) => {})",
-}
-`;
-
-exports[`#311 - acorn loose - () => {} 1`] = `
+exports[`#329 - acorn loose - () => {} 1`] = `
 Object {
   "args": Array [],
   "body": "",
   "defaults": Object {},
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -12550,29 +7577,7 @@ Object {
 }
 `;
 
-exports[`#311 - acorn loose - (a) => a * 3 * a 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "a * 3 * a",
-  "defaults": Object {
-    "a": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": false,
-  "isExpression": true,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "((a) => a * 3 * a)",
-}
-`;
-
-exports[`#312 - acorn loose - (a = (true, false)) => {} 1`] = `
+exports[`#330 - acorn loose - (a = (true, false)) => {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -12581,6 +7586,7 @@ Object {
   "defaults": Object {
     "a": "false",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -12594,29 +7600,7 @@ Object {
 }
 `;
 
-exports[`#312 - acorn loose - d => d * 355 * d 1`] = `
-Object {
-  "args": Array [
-    "d",
-  ],
-  "body": "d * 355 * d",
-  "defaults": Object {
-    "d": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": false,
-  "isExpression": true,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "d",
-  "value": "(d => d * 355 * d)",
-}
-`;
-
-exports[`#313 - acorn loose - (a = (true, null)) => {} 1`] = `
+exports[`#331 - acorn loose - (a = (true, null)) => {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -12625,6 +7609,7 @@ Object {
   "defaults": Object {
     "a": "null",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -12638,29 +7623,7 @@ Object {
 }
 `;
 
-exports[`#313 - acorn loose - e => {return e + 5235 / e} 1`] = `
-Object {
-  "args": Array [
-    "e",
-  ],
-  "body": "return e + 5235 / e",
-  "defaults": Object {
-    "e": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "e",
-  "value": "(e => {return e + 5235 / e})",
-}
-`;
-
-exports[`#314 - acorn loose - (a = (true, "bar")) => {} 1`] = `
+exports[`#332 - acorn loose - (a = (true, "bar")) => {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -12669,6 +7632,7 @@ Object {
   "defaults": Object {
     "a": "\\"bar\\"",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -12682,31 +7646,7 @@ Object {
 }
 `;
 
-exports[`#314 - acorn loose - (a, b) => a + 3 + b 1`] = `
-Object {
-  "args": Array [
-    "a",
-    "b",
-  ],
-  "body": "a + 3 + b",
-  "defaults": Object {
-    "a": undefined,
-    "b": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": false,
-  "isExpression": true,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a, b",
-  "value": "((a, b) => a + 3 + b)",
-}
-`;
-
-exports[`#315 - acorn loose - (a, b = (i++, true)) => {} 1`] = `
+exports[`#333 - acorn loose - (a, b = (i++, true)) => {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -12717,6 +7657,7 @@ Object {
     "a": undefined,
     "b": "true",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -12730,33 +7671,7 @@ Object {
 }
 `;
 
-exports[`#315 - acorn loose - (x, y, ...restArgs) => console.log({ value: x * y }) 1`] = `
-Object {
-  "args": Array [
-    "x",
-    "y",
-    "restArgs",
-  ],
-  "body": "console.log({ value: x * y })",
-  "defaults": Object {
-    "restArgs": undefined,
-    "x": undefined,
-    "y": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": false,
-  "isExpression": true,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "x, y, restArgs",
-  "value": "((x, y, ...restArgs) => console.log({ value: x * y }))",
-}
-`;
-
-exports[`#316 - acorn loose - (a = 1) => {} 1`] = `
+exports[`#334 - acorn loose - (a = 1) => {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -12765,6 +7680,7 @@ Object {
   "defaults": Object {
     "a": "1",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -12778,33 +7694,7 @@ Object {
 }
 `;
 
-exports[`#316 - acorn loose - async function (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
-Object {
-  "args": Array [
-    "a",
-    "cb",
-    "restArgs",
-  ],
-  "body": "return a * 3",
-  "defaults": Object {
-    "a": "{foo: \\"ba)r\\", baz: 123}",
-    "cb": undefined,
-    "restArgs": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a, cb, restArgs",
-  "value": "(async function (a = {foo: \\"ba)r\\", baz: 123}, cb, ...restArgs) {return a * 3})",
-}
-`;
-
-exports[`#317 - acorn loose - (a) => a * 3 * a 1`] = `
+exports[`#335 - acorn loose - (a) => a * 3 * a 1`] = `
 Object {
   "args": Array [
     "a",
@@ -12813,6 +7703,7 @@ Object {
   "defaults": Object {
     "a": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -12826,55 +7717,7 @@ Object {
 }
 `;
 
-exports[`#317 - acorn loose - async function (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
-Object {
-  "args": Array [
-    "b",
-    "callback",
-    "restArgs",
-  ],
-  "body": "callback(null, b + 3)",
-  "defaults": Object {
-    "b": undefined,
-    "callback": undefined,
-    "restArgs": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "b, callback, restArgs",
-  "value": "(async function (b, callback, ...restArgs) {callback(null, b + 3)})",
-}
-`;
-
-exports[`#318 - acorn loose - async function (c) {return c * 3} 1`] = `
-Object {
-  "args": Array [
-    "c",
-  ],
-  "body": "return c * 3",
-  "defaults": Object {
-    "c": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "c",
-  "value": "(async function (c) {return c * 3})",
-}
-`;
-
-exports[`#318 - acorn loose - d => d * 355 * d 1`] = `
+exports[`#336 - acorn loose - d => d * 355 * d 1`] = `
 Object {
   "args": Array [
     "d",
@@ -12883,6 +7726,7 @@ Object {
   "defaults": Object {
     "d": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -12896,29 +7740,7 @@ Object {
 }
 `;
 
-exports[`#319 - acorn loose - async function (...restArgs) {return 321} 1`] = `
-Object {
-  "args": Array [
-    "restArgs",
-  ],
-  "body": "return 321",
-  "defaults": Object {
-    "restArgs": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "restArgs",
-  "value": "(async function (...restArgs) {return 321})",
-}
-`;
-
-exports[`#319 - acorn loose - e => {return e + 5235 / e} 1`] = `
+exports[`#337 - acorn loose - e => {return e + 5235 / e} 1`] = `
 Object {
   "args": Array [
     "e",
@@ -12927,6 +7749,7 @@ Object {
   "defaults": Object {
     "e": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -12940,7 +7763,7 @@ Object {
 }
 `;
 
-exports[`#320 - acorn loose - (a, b) => a + 3 + b 1`] = `
+exports[`#338 - acorn loose - (a, b) => a + 3 + b 1`] = `
 Object {
   "args": Array [
     "a",
@@ -12951,6 +7774,7 @@ Object {
     "a": undefined,
     "b": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -12964,25 +7788,7 @@ Object {
 }
 `;
 
-exports[`#320 - acorn loose - async function () {} 1`] = `
-Object {
-  "args": Array [],
-  "body": "",
-  "defaults": Object {},
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "",
-  "value": "(async function () {})",
-}
-`;
-
-exports[`#321 - acorn loose - (x, y, ...restArgs) => console.log({ value: x * y }) 1`] = `
+exports[`#339 - acorn loose - (x, y, ...restArgs) => console.log({ value: x * y }) 1`] = `
 Object {
   "args": Array [
     "x",
@@ -12995,6 +7801,7 @@ Object {
     "x": undefined,
     "y": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -13008,36 +7815,19 @@ Object {
 }
 `;
 
-exports[`#321 - acorn loose - async function (a = (true, false)) {} 1`] = `
+exports[`#340 - acorn loose - ({x, y}) => {} 1`] = `
 Object {
   "args": Array [
-    "a",
+    false,
   ],
   "body": "",
   "defaults": Object {
-    "a": "false",
+    "false": undefined,
   },
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "(async function (a = (true, false)) {})",
-}
-`;
-
-exports[`#322 - acorn loose - ({x, y}) => {} 1`] = `
-Object {
-  "args": Array [
+  "destructuredArgs": Array [
     "x",
     "y",
   ],
-  "body": "",
-  "defaults": Object {},
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -13046,56 +7836,12 @@ Object {
   "isNamed": false,
   "isValid": true,
   "name": null,
-  "params": "x, y",
+  "params": "false",
   "value": "(({x, y}) => {})",
 }
 `;
 
-exports[`#322 - acorn loose - async function (a = (true, null)) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "null",
-  },
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "(async function (a = (true, null)) {})",
-}
-`;
-
-exports[`#323 - acorn loose - async function (a = (true, "bar")) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "\\"bar\\"",
-  },
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "(async function (a = (true, \\"bar\\")) {})",
-}
-`;
-
-exports[`#323 - acorn loose - async function (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
+exports[`#341 - acorn loose - async function (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -13108,6 +7854,7 @@ Object {
     "cb": undefined,
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": true,
@@ -13121,31 +7868,7 @@ Object {
 }
 `;
 
-exports[`#324 - acorn loose - async function (a, b = (i++, true)) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-    "b",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": undefined,
-    "b": "true",
-  },
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a, b",
-  "value": "(async function (a, b = (i++, true)) {})",
-}
-`;
-
-exports[`#324 - acorn loose - async function (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
+exports[`#342 - acorn loose - async function (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
 Object {
   "args": Array [
     "b",
@@ -13158,6 +7881,7 @@ Object {
     "callback": undefined,
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": true,
@@ -13171,29 +7895,7 @@ Object {
 }
 `;
 
-exports[`#325 - acorn loose - async function (a = 1) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "1",
-  },
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "(async function (a = 1) {})",
-}
-`;
-
-exports[`#325 - acorn loose - async function (c) {return c * 3} 1`] = `
+exports[`#343 - acorn loose - async function (c) {return c * 3} 1`] = `
 Object {
   "args": Array [
     "c",
@@ -13202,6 +7904,7 @@ Object {
   "defaults": Object {
     "c": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": true,
@@ -13215,7 +7918,7 @@ Object {
 }
 `;
 
-exports[`#326 - acorn loose - async function (...restArgs) {return 321} 1`] = `
+exports[`#344 - acorn loose - async function (...restArgs) {return 321} 1`] = `
 Object {
   "args": Array [
     "restArgs",
@@ -13224,6 +7927,7 @@ Object {
   "defaults": Object {
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": true,
@@ -13237,37 +7941,12 @@ Object {
 }
 `;
 
-exports[`#326 - acorn loose - async function namedFn (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
-Object {
-  "args": Array [
-    "a",
-    "cb",
-    "restArgs",
-  ],
-  "body": "return a * 3",
-  "defaults": Object {
-    "a": "{foo: \\"ba)r\\", baz: 123}",
-    "cb": undefined,
-    "restArgs": undefined,
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "a, cb, restArgs",
-  "value": "(async function namedFn (a = {foo: \\"ba)r\\", baz: 123}, cb, ...restArgs) {return a * 3})",
-}
-`;
-
-exports[`#327 - acorn loose - async function () {} 1`] = `
+exports[`#345 - acorn loose - async function () {} 1`] = `
 Object {
   "args": Array [],
   "body": "",
   "defaults": Object {},
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": true,
@@ -13281,33 +7960,7 @@ Object {
 }
 `;
 
-exports[`#327 - acorn loose - async function namedFn (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
-Object {
-  "args": Array [
-    "b",
-    "callback",
-    "restArgs",
-  ],
-  "body": "callback(null, b + 3)",
-  "defaults": Object {
-    "b": undefined,
-    "callback": undefined,
-    "restArgs": undefined,
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "b, callback, restArgs",
-  "value": "(async function namedFn (b, callback, ...restArgs) {callback(null, b + 3)})",
-}
-`;
-
-exports[`#328 - acorn loose - async function (a = (true, false)) {} 1`] = `
+exports[`#346 - acorn loose - async function (a = (true, false)) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -13316,6 +7969,7 @@ Object {
   "defaults": Object {
     "a": "false",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": true,
@@ -13329,29 +7983,7 @@ Object {
 }
 `;
 
-exports[`#328 - acorn loose - async function namedFn (c) {return c * 3} 1`] = `
-Object {
-  "args": Array [
-    "c",
-  ],
-  "body": "return c * 3",
-  "defaults": Object {
-    "c": undefined,
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "c",
-  "value": "(async function namedFn (c) {return c * 3})",
-}
-`;
-
-exports[`#329 - acorn loose - async function (a = (true, null)) {} 1`] = `
+exports[`#347 - acorn loose - async function (a = (true, null)) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -13360,6 +7992,7 @@ Object {
   "defaults": Object {
     "a": "null",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": true,
@@ -13373,29 +8006,7 @@ Object {
 }
 `;
 
-exports[`#329 - acorn loose - async function namedFn (...restArgs) {return 321} 1`] = `
-Object {
-  "args": Array [
-    "restArgs",
-  ],
-  "body": "return 321",
-  "defaults": Object {
-    "restArgs": undefined,
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "restArgs",
-  "value": "(async function namedFn (...restArgs) {return 321})",
-}
-`;
-
-exports[`#330 - acorn loose - async function (a = (true, "bar")) {} 1`] = `
+exports[`#348 - acorn loose - async function (a = (true, "bar")) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -13404,6 +8015,7 @@ Object {
   "defaults": Object {
     "a": "\\"bar\\"",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": true,
@@ -13417,25 +8029,7 @@ Object {
 }
 `;
 
-exports[`#330 - acorn loose - async function namedFn () {} 1`] = `
-Object {
-  "args": Array [],
-  "body": "",
-  "defaults": Object {},
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "",
-  "value": "(async function namedFn () {})",
-}
-`;
-
-exports[`#331 - acorn loose - async function (a, b = (i++, true)) {} 1`] = `
+exports[`#349 - acorn loose - async function (a, b = (i++, true)) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -13446,6 +8040,7 @@ Object {
     "a": undefined,
     "b": "true",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": true,
@@ -13459,29 +8054,7 @@ Object {
 }
 `;
 
-exports[`#331 - acorn loose - async function namedFn(a = (true, false)) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "false",
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "a",
-  "value": "(async function namedFn(a = (true, false)) {})",
-}
-`;
-
-exports[`#332 - acorn loose - async function (a = 1) {} 1`] = `
+exports[`#350 - acorn loose - async function (a = 1) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -13490,6 +8063,7 @@ Object {
   "defaults": Object {
     "a": "1",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": true,
@@ -13503,29 +8077,33 @@ Object {
 }
 `;
 
-exports[`#332 - acorn loose - async function namedFn(a = (true, null)) {} 1`] = `
+exports[`#351 - acorn loose - async function ({x, y}) {} 1`] = `
 Object {
   "args": Array [
-    "a",
+    false,
   ],
   "body": "",
   "defaults": Object {
-    "a": "null",
+    "false": undefined,
   },
-  "isAnonymous": false,
+  "destructuredArgs": Array [
+    "x",
+    "y",
+  ],
+  "isAnonymous": true,
   "isArrow": false,
   "isAsync": true,
   "isExpression": false,
   "isGenerator": false,
-  "isNamed": true,
+  "isNamed": false,
   "isValid": true,
-  "name": "namedFn",
-  "params": "a",
-  "value": "(async function namedFn(a = (true, null)) {})",
+  "name": null,
+  "params": "false",
+  "value": "(async function ({x, y}) {})",
 }
 `;
 
-exports[`#333 - acorn loose - async function namedFn (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
+exports[`#352 - acorn loose - async function namedFn (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -13538,6 +8116,7 @@ Object {
     "cb": undefined,
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": true,
@@ -13551,29 +8130,7 @@ Object {
 }
 `;
 
-exports[`#333 - acorn loose - async function namedFn(a = (true, "bar")) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "\\"bar\\"",
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "a",
-  "value": "(async function namedFn(a = (true, \\"bar\\")) {})",
-}
-`;
-
-exports[`#334 - acorn loose - async function namedFn (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
+exports[`#353 - acorn loose - async function namedFn (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
 Object {
   "args": Array [
     "b",
@@ -13586,6 +8143,7 @@ Object {
     "callback": undefined,
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": true,
@@ -13599,31 +8157,7 @@ Object {
 }
 `;
 
-exports[`#334 - acorn loose - async function namedFn(a, b = (i++, true)) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-    "b",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": undefined,
-    "b": "true",
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "a, b",
-  "value": "(async function namedFn(a, b = (i++, true)) {})",
-}
-`;
-
-exports[`#335 - acorn loose - async function namedFn (c) {return c * 3} 1`] = `
+exports[`#354 - acorn loose - async function namedFn (c) {return c * 3} 1`] = `
 Object {
   "args": Array [
     "c",
@@ -13632,6 +8166,7 @@ Object {
   "defaults": Object {
     "c": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": true,
@@ -13645,55 +8180,7 @@ Object {
 }
 `;
 
-exports[`#335 - acorn loose - async function namedFn(a = 1) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "1",
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "a",
-  "value": "(async function namedFn(a = 1) {})",
-}
-`;
-
-exports[`#336 - acorn loose - async (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) => {return a * 3} 1`] = `
-Object {
-  "args": Array [
-    "a",
-    "cb",
-    "restArgs",
-  ],
-  "body": "return a * 3",
-  "defaults": Object {
-    "a": "{foo: \\"ba)r\\", baz: 123}",
-    "cb": undefined,
-    "restArgs": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a, cb, restArgs",
-  "value": "(async (a = {foo: \\"ba)r\\", baz: 123}, cb, ...restArgs) => {return a * 3})",
-}
-`;
-
-exports[`#336 - acorn loose - async function namedFn (...restArgs) {return 321} 1`] = `
+exports[`#355 - acorn loose - async function namedFn (...restArgs) {return 321} 1`] = `
 Object {
   "args": Array [
     "restArgs",
@@ -13702,6 +8189,7 @@ Object {
   "defaults": Object {
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": true,
@@ -13715,37 +8203,12 @@ Object {
 }
 `;
 
-exports[`#337 - acorn loose - async (b, callback, ...restArgs) => {callback(null, b + 3)} 1`] = `
-Object {
-  "args": Array [
-    "b",
-    "callback",
-    "restArgs",
-  ],
-  "body": "callback(null, b + 3)",
-  "defaults": Object {
-    "b": undefined,
-    "callback": undefined,
-    "restArgs": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "b, callback, restArgs",
-  "value": "(async (b, callback, ...restArgs) => {callback(null, b + 3)})",
-}
-`;
-
-exports[`#337 - acorn loose - async function namedFn () {} 1`] = `
+exports[`#356 - acorn loose - async function namedFn () {} 1`] = `
 Object {
   "args": Array [],
   "body": "",
   "defaults": Object {},
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": true,
@@ -13759,29 +8222,7 @@ Object {
 }
 `;
 
-exports[`#338 - acorn loose - async (c) => {return c * 3} 1`] = `
-Object {
-  "args": Array [
-    "c",
-  ],
-  "body": "return c * 3",
-  "defaults": Object {
-    "c": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "c",
-  "value": "(async (c) => {return c * 3})",
-}
-`;
-
-exports[`#338 - acorn loose - async function namedFn(a = (true, false)) {} 1`] = `
+exports[`#357 - acorn loose - async function namedFn(a = (true, false)) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -13790,6 +8231,7 @@ Object {
   "defaults": Object {
     "a": "false",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": true,
@@ -13803,29 +8245,7 @@ Object {
 }
 `;
 
-exports[`#339 - acorn loose - async (...restArgs) => {return 321} 1`] = `
-Object {
-  "args": Array [
-    "restArgs",
-  ],
-  "body": "return 321",
-  "defaults": Object {
-    "restArgs": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "restArgs",
-  "value": "(async (...restArgs) => {return 321})",
-}
-`;
-
-exports[`#339 - acorn loose - async function namedFn(a = (true, null)) {} 1`] = `
+exports[`#358 - acorn loose - async function namedFn(a = (true, null)) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -13834,6 +8254,7 @@ Object {
   "defaults": Object {
     "a": "null",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": true,
@@ -13847,25 +8268,7 @@ Object {
 }
 `;
 
-exports[`#340 - acorn loose - async () => {} 1`] = `
-Object {
-  "args": Array [],
-  "body": "",
-  "defaults": Object {},
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "",
-  "value": "(async () => {})",
-}
-`;
-
-exports[`#340 - acorn loose - async function namedFn(a = (true, "bar")) {} 1`] = `
+exports[`#359 - acorn loose - async function namedFn(a = (true, "bar")) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -13874,6 +8277,7 @@ Object {
   "defaults": Object {
     "a": "\\"bar\\"",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": true,
@@ -13887,29 +8291,7 @@ Object {
 }
 `;
 
-exports[`#341 - acorn loose - async (a = (true, false)) => {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "false",
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "(async (a = (true, false)) => {})",
-}
-`;
-
-exports[`#341 - acorn loose - async function namedFn(a, b = (i++, true)) {} 1`] = `
+exports[`#360 - acorn loose - async function namedFn(a, b = (i++, true)) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -13920,6 +8302,7 @@ Object {
     "a": undefined,
     "b": "true",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": true,
@@ -13933,29 +8316,7 @@ Object {
 }
 `;
 
-exports[`#342 - acorn loose - async (a = (true, null)) => {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "null",
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "(async (a = (true, null)) => {})",
-}
-`;
-
-exports[`#342 - acorn loose - async function namedFn(a = 1) {} 1`] = `
+exports[`#361 - acorn loose - async function namedFn(a = 1) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -13964,6 +8325,7 @@ Object {
   "defaults": Object {
     "a": "1",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": true,
@@ -13977,29 +8339,33 @@ Object {
 }
 `;
 
-exports[`#343 - acorn loose - async (a = (true, "bar")) => {} 1`] = `
+exports[`#362 - acorn loose - async function namedFn({x, y}) {} 1`] = `
 Object {
   "args": Array [
-    "a",
+    false,
   ],
   "body": "",
   "defaults": Object {
-    "a": "\\"bar\\"",
+    "false": undefined,
   },
-  "isAnonymous": true,
-  "isArrow": true,
+  "destructuredArgs": Array [
+    "x",
+    "y",
+  ],
+  "isAnonymous": false,
+  "isArrow": false,
   "isAsync": true,
   "isExpression": false,
   "isGenerator": false,
-  "isNamed": false,
+  "isNamed": true,
   "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "(async (a = (true, \\"bar\\")) => {})",
+  "name": "namedFn",
+  "params": "false",
+  "value": "(async function namedFn({x, y}) {})",
 }
 `;
 
-exports[`#343 - acorn loose - async (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) => {return a * 3} 1`] = `
+exports[`#363 - acorn loose - async (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) => {return a * 3} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -14012,6 +8378,7 @@ Object {
     "cb": undefined,
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -14025,31 +8392,7 @@ Object {
 }
 `;
 
-exports[`#344 - acorn loose - async (a, b = (i++, true)) => {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-    "b",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": undefined,
-    "b": "true",
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a, b",
-  "value": "(async (a, b = (i++, true)) => {})",
-}
-`;
-
-exports[`#344 - acorn loose - async (b, callback, ...restArgs) => {callback(null, b + 3)} 1`] = `
+exports[`#364 - acorn loose - async (b, callback, ...restArgs) => {callback(null, b + 3)} 1`] = `
 Object {
   "args": Array [
     "b",
@@ -14062,6 +8405,7 @@ Object {
     "callback": undefined,
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -14075,29 +8419,7 @@ Object {
 }
 `;
 
-exports[`#345 - acorn loose - async (a = 1) => {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "1",
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "(async (a = 1) => {})",
-}
-`;
-
-exports[`#345 - acorn loose - async (c) => {return c * 3} 1`] = `
+exports[`#365 - acorn loose - async (c) => {return c * 3} 1`] = `
 Object {
   "args": Array [
     "c",
@@ -14106,6 +8428,7 @@ Object {
   "defaults": Object {
     "c": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -14119,7 +8442,7 @@ Object {
 }
 `;
 
-exports[`#346 - acorn loose - async (...restArgs) => {return 321} 1`] = `
+exports[`#366 - acorn loose - async (...restArgs) => {return 321} 1`] = `
 Object {
   "args": Array [
     "restArgs",
@@ -14128,6 +8451,7 @@ Object {
   "defaults": Object {
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -14141,33 +8465,12 @@ Object {
 }
 `;
 
-exports[`#346 - acorn loose - async (a) => a * 3 * a 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "a * 3 * a",
-  "defaults": Object {
-    "a": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": true,
-  "isExpression": true,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "(async (a) => a * 3 * a)",
-}
-`;
-
-exports[`#347 - acorn loose - async () => {} 1`] = `
+exports[`#367 - acorn loose - async () => {} 1`] = `
 Object {
   "args": Array [],
   "body": "",
   "defaults": Object {},
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -14181,29 +8484,7 @@ Object {
 }
 `;
 
-exports[`#347 - acorn loose - async d => d * 355 * d 1`] = `
-Object {
-  "args": Array [
-    "d",
-  ],
-  "body": "d * 355 * d",
-  "defaults": Object {
-    "d": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": true,
-  "isExpression": true,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "d",
-  "value": "(async d => d * 355 * d)",
-}
-`;
-
-exports[`#348 - acorn loose - async (a = (true, false)) => {} 1`] = `
+exports[`#368 - acorn loose - async (a = (true, false)) => {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -14212,6 +8493,7 @@ Object {
   "defaults": Object {
     "a": "false",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -14225,29 +8507,7 @@ Object {
 }
 `;
 
-exports[`#348 - acorn loose - async e => {return e + 5235 / e} 1`] = `
-Object {
-  "args": Array [
-    "e",
-  ],
-  "body": "return e + 5235 / e",
-  "defaults": Object {
-    "e": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "e",
-  "value": "(async e => {return e + 5235 / e})",
-}
-`;
-
-exports[`#349 - acorn loose - async (a = (true, null)) => {} 1`] = `
+exports[`#369 - acorn loose - async (a = (true, null)) => {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -14256,6 +8516,7 @@ Object {
   "defaults": Object {
     "a": "null",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -14269,31 +8530,7 @@ Object {
 }
 `;
 
-exports[`#349 - acorn loose - async (a, b) => a + 3 + b 1`] = `
-Object {
-  "args": Array [
-    "a",
-    "b",
-  ],
-  "body": "a + 3 + b",
-  "defaults": Object {
-    "a": undefined,
-    "b": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": true,
-  "isExpression": true,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a, b",
-  "value": "(async (a, b) => a + 3 + b)",
-}
-`;
-
-exports[`#350 - acorn loose - async (a = (true, "bar")) => {} 1`] = `
+exports[`#370 - acorn loose - async (a = (true, "bar")) => {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -14302,6 +8539,7 @@ Object {
   "defaults": Object {
     "a": "\\"bar\\"",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -14315,33 +8553,7 @@ Object {
 }
 `;
 
-exports[`#350 - acorn loose - async (x, y, ...restArgs) => console.log({ value: x * y }) 1`] = `
-Object {
-  "args": Array [
-    "x",
-    "y",
-    "restArgs",
-  ],
-  "body": "console.log({ value: x * y })",
-  "defaults": Object {
-    "restArgs": undefined,
-    "x": undefined,
-    "y": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": true,
-  "isExpression": true,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "x, y, restArgs",
-  "value": "(async (x, y, ...restArgs) => console.log({ value: x * y }))",
-}
-`;
-
-exports[`#351 - acorn loose - async (a, b = (i++, true)) => {} 1`] = `
+exports[`#371 - acorn loose - async (a, b = (i++, true)) => {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -14352,6 +8564,7 @@ Object {
     "a": undefined,
     "b": "true",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -14365,25 +8578,7 @@ Object {
 }
 `;
 
-exports[`#351 - acorn loose - should return object with default values when invalid 1`] = `
-Object {
-  "args": Array [],
-  "body": "",
-  "defaults": Object {},
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": false,
-  "name": null,
-  "params": "",
-  "value": "",
-}
-`;
-
-exports[`#352 - acorn loose - async (a = 1) => {} 1`] = `
+exports[`#372 - acorn loose - async (a = 1) => {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -14392,6 +8587,7 @@ Object {
   "defaults": Object {
     "a": "1",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -14405,25 +8601,7 @@ Object {
 }
 `;
 
-exports[`#352 - acorn loose - should have '.isValid' and few '.is*'' hidden properties 1`] = `
-Object {
-  "args": Array [],
-  "body": "",
-  "defaults": Object {},
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": false,
-  "name": null,
-  "params": "",
-  "value": "",
-}
-`;
-
-exports[`#353 - acorn loose - async (a) => a * 3 * a 1`] = `
+exports[`#373 - acorn loose - async (a) => a * 3 * a 1`] = `
 Object {
   "args": Array [
     "a",
@@ -14432,6 +8610,7 @@ Object {
   "defaults": Object {
     "a": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -14445,7 +8624,7 @@ Object {
 }
 `;
 
-exports[`#354 - acorn loose - async d => d * 355 * d 1`] = `
+exports[`#374 - acorn loose - async d => d * 355 * d 1`] = `
 Object {
   "args": Array [
     "d",
@@ -14454,6 +8633,7 @@ Object {
   "defaults": Object {
     "d": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -14467,7 +8647,7 @@ Object {
 }
 `;
 
-exports[`#355 - acorn loose - async e => {return e + 5235 / e} 1`] = `
+exports[`#375 - acorn loose - async e => {return e + 5235 / e} 1`] = `
 Object {
   "args": Array [
     "e",
@@ -14476,6 +8656,7 @@ Object {
   "defaults": Object {
     "e": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -14489,7 +8670,7 @@ Object {
 }
 `;
 
-exports[`#356 - acorn loose - async (a, b) => a + 3 + b 1`] = `
+exports[`#376 - acorn loose - async (a, b) => a + 3 + b 1`] = `
 Object {
   "args": Array [
     "a",
@@ -14500,6 +8681,7 @@ Object {
     "a": undefined,
     "b": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -14513,7 +8695,7 @@ Object {
 }
 `;
 
-exports[`#357 - acorn loose - async (x, y, ...restArgs) => console.log({ value: x * y }) 1`] = `
+exports[`#377 - acorn loose - async (x, y, ...restArgs) => console.log({ value: x * y }) 1`] = `
 Object {
   "args": Array [
     "x",
@@ -14526,6 +8708,7 @@ Object {
     "x": undefined,
     "y": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -14539,122 +8722,19 @@ Object {
 }
 `;
 
-exports[`#357 - acorn loose - should work for object methods 1`] = `
+exports[`#378 - acorn loose - async ({x, y}) => {} 1`] = `
 Object {
   "args": Array [
-    "a",
-    "b",
-    "c",
+    false,
   ],
-  "body": "
-        return 123;
-      ",
+  "body": "",
   "defaults": Object {
-    "a": undefined,
-    "b": undefined,
-    "c": undefined,
+    "false": undefined,
   },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "foo",
-  "params": "a, b, c",
-  "value": "({ foo(a, b, c) {
-        return 123;
-      } })",
-}
-`;
-
-exports[`#357 - acorn loose - should work for object methods 2`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "
-        return () => a;
-      ",
-  "defaults": Object {
-    "a": undefined,
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "bar",
-  "params": "a",
-  "value": "({ bar(a) {
-        return () => a;
-      } })",
-}
-`;
-
-exports[`#357 - acorn loose - should work for object methods 3`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "
-        return yield a * 321;
-      ",
-  "defaults": Object {
-    "a": undefined,
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": true,
-  "isNamed": true,
-  "isValid": true,
-  "name": "gen",
-  "params": "a",
-  "value": "({ *gen(a) {
-        return yield a * 321;
-      } })",
-}
-`;
-
-exports[`#357 - acorn loose - should work for object methods 4`] = `
-Object {
-  "args": Array [
-    "a",
-    "cb",
-    "restArgs",
-  ],
-  "body": " return a * 3 ",
-  "defaults": Object {
-    "a": "{foo: 'ba)r', baz: 123}",
-    "cb": undefined,
-    "restArgs": undefined,
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "a, cb, restArgs",
-  "value": "({ namedFn (a = {foo: 'ba)r', baz: 123}, cb, ...restArgs) { return a * 3 } })",
-}
-`;
-
-exports[`#358 - acorn loose - async ({x, y}) => {} 1`] = `
-Object {
-  "args": Array [
+  "destructuredArgs": Array [
     "x",
     "y",
   ],
-  "body": "",
-  "defaults": Object {},
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -14663,12 +8743,12 @@ Object {
   "isNamed": false,
   "isValid": true,
   "name": null,
-  "params": "x, y",
+  "params": "false",
   "value": "(async ({x, y}) => {})",
 }
 `;
 
-exports[`#359 - acorn loose - should return object with default values when invalid 1`] = `
+exports[`#379 - acorn loose - should return object with default values when invalid 1`] = `
 Object {
   "args": Array [],
   "body": "",
@@ -14686,7 +8766,7 @@ Object {
 }
 `;
 
-exports[`#360 - acorn loose - should have '.isValid' and few '.is*'' hidden properties 1`] = `
+exports[`#380 - acorn loose - should have '.isValid' and few '.is*'' hidden properties 1`] = `
 Object {
   "args": Array [],
   "body": "",
@@ -14704,103 +8784,7 @@ Object {
 }
 `;
 
-exports[`#361 - espree.parse - function (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
-Object {
-  "args": Array [
-    "a",
-    "cb",
-    "restArgs",
-  ],
-  "body": "return a * 3",
-  "defaults": Object {
-    "a": "{foo: \\"ba)r\\", baz: 123}",
-    "cb": undefined,
-    "restArgs": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a, cb, restArgs",
-  "value": "(function (a = {foo: \\"ba)r\\", baz: 123}, cb, ...restArgs) {return a * 3})",
-}
-`;
-
-exports[`#362 - espree.parse - function (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
-Object {
-  "args": Array [
-    "b",
-    "callback",
-    "restArgs",
-  ],
-  "body": "callback(null, b + 3)",
-  "defaults": Object {
-    "b": undefined,
-    "callback": undefined,
-    "restArgs": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "b, callback, restArgs",
-  "value": "(function (b, callback, ...restArgs) {callback(null, b + 3)})",
-}
-`;
-
-exports[`#363 - espree.parse - function (c) {return c * 3} 1`] = `
-Object {
-  "args": Array [
-    "c",
-  ],
-  "body": "return c * 3",
-  "defaults": Object {
-    "c": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "c",
-  "value": "(function (c) {return c * 3})",
-}
-`;
-
-exports[`#364 - espree.parse - function (...restArgs) {return 321} 1`] = `
-Object {
-  "args": Array [
-    "restArgs",
-  ],
-  "body": "return 321",
-  "defaults": Object {
-    "restArgs": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "restArgs",
-  "value": "(function (...restArgs) {return 321})",
-}
-`;
-
-exports[`#365 - acorn loose - should work for object methods 1`] = `
+exports[`#385 - acorn loose - should work for object methods 1`] = `
 Object {
   "args": Array [
     "a",
@@ -14815,6 +8799,7 @@ Object {
     "b": undefined,
     "c": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -14830,7 +8815,7 @@ Object {
 }
 `;
 
-exports[`#365 - acorn loose - should work for object methods 2`] = `
+exports[`#385 - acorn loose - should work for object methods 2`] = `
 Object {
   "args": Array [
     "a",
@@ -14841,6 +8826,7 @@ Object {
   "defaults": Object {
     "a": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -14856,7 +8842,7 @@ Object {
 }
 `;
 
-exports[`#365 - acorn loose - should work for object methods 3`] = `
+exports[`#385 - acorn loose - should work for object methods 3`] = `
 Object {
   "args": Array [
     "a",
@@ -14867,6 +8853,7 @@ Object {
   "defaults": Object {
     "a": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -14882,7 +8869,7 @@ Object {
 }
 `;
 
-exports[`#365 - acorn loose - should work for object methods 4`] = `
+exports[`#385 - acorn loose - should work for object methods 4`] = `
 Object {
   "args": Array [
     "a",
@@ -14895,6 +8882,7 @@ Object {
     "cb": undefined,
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -14908,91 +8896,7 @@ Object {
 }
 `;
 
-exports[`#365 - espree.parse - function () {} 1`] = `
-Object {
-  "args": Array [],
-  "body": "",
-  "defaults": Object {},
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "",
-  "value": "(function () {})",
-}
-`;
-
-exports[`#366 - espree.parse - function (a = (true, false)) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "false",
-  },
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "(function (a = (true, false)) {})",
-}
-`;
-
-exports[`#367 - espree.parse - function (a = (true, null)) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "null",
-  },
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "(function (a = (true, null)) {})",
-}
-`;
-
-exports[`#368 - espree.parse - function (a = (true, "bar")) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "\\"bar\\"",
-  },
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "(function (a = (true, \\"bar\\")) {})",
-}
-`;
-
-exports[`#369 - espree.parse - function (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
+exports[`#389 - espree.parse - function (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -15005,6 +8909,7 @@ Object {
     "cb": undefined,
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": false,
@@ -15018,53 +8923,7 @@ Object {
 }
 `;
 
-exports[`#369 - espree.parse - function (a, b = (i++, true)) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-    "b",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": undefined,
-    "b": "true",
-  },
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a, b",
-  "value": "(function (a, b = (i++, true)) {})",
-}
-`;
-
-exports[`#370 - espree.parse - function (a = 1) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "1",
-  },
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "(function (a = 1) {})",
-}
-`;
-
-exports[`#370 - espree.parse - function (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
+exports[`#390 - espree.parse - function (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
 Object {
   "args": Array [
     "b",
@@ -15077,6 +8936,7 @@ Object {
     "callback": undefined,
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": false,
@@ -15090,7 +8950,7 @@ Object {
 }
 `;
 
-exports[`#371 - espree.parse - function (c) {return c * 3} 1`] = `
+exports[`#391 - espree.parse - function (c) {return c * 3} 1`] = `
 Object {
   "args": Array [
     "c",
@@ -15099,6 +8959,7 @@ Object {
   "defaults": Object {
     "c": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": false,
@@ -15112,33 +8973,7 @@ Object {
 }
 `;
 
-exports[`#371 - espree.parse - function namedFn (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
-Object {
-  "args": Array [
-    "a",
-    "cb",
-    "restArgs",
-  ],
-  "body": "return a * 3",
-  "defaults": Object {
-    "a": "{foo: \\"ba)r\\", baz: 123}",
-    "cb": undefined,
-    "restArgs": undefined,
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "a, cb, restArgs",
-  "value": "(function namedFn (a = {foo: \\"ba)r\\", baz: 123}, cb, ...restArgs) {return a * 3})",
-}
-`;
-
-exports[`#372 - espree.parse - function (...restArgs) {return 321} 1`] = `
+exports[`#392 - espree.parse - function (...restArgs) {return 321} 1`] = `
 Object {
   "args": Array [
     "restArgs",
@@ -15147,6 +8982,7 @@ Object {
   "defaults": Object {
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": false,
@@ -15160,37 +8996,12 @@ Object {
 }
 `;
 
-exports[`#372 - espree.parse - function namedFn (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
-Object {
-  "args": Array [
-    "b",
-    "callback",
-    "restArgs",
-  ],
-  "body": "callback(null, b + 3)",
-  "defaults": Object {
-    "b": undefined,
-    "callback": undefined,
-    "restArgs": undefined,
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "b, callback, restArgs",
-  "value": "(function namedFn (b, callback, ...restArgs) {callback(null, b + 3)})",
-}
-`;
-
-exports[`#373 - espree.parse - function () {} 1`] = `
+exports[`#393 - espree.parse - function () {} 1`] = `
 Object {
   "args": Array [],
   "body": "",
   "defaults": Object {},
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": false,
@@ -15204,29 +9015,7 @@ Object {
 }
 `;
 
-exports[`#373 - espree.parse - function namedFn (c) {return c * 3} 1`] = `
-Object {
-  "args": Array [
-    "c",
-  ],
-  "body": "return c * 3",
-  "defaults": Object {
-    "c": undefined,
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "c",
-  "value": "(function namedFn (c) {return c * 3})",
-}
-`;
-
-exports[`#374 - espree.parse - function (a = (true, false)) {} 1`] = `
+exports[`#394 - espree.parse - function (a = (true, false)) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -15235,6 +9024,7 @@ Object {
   "defaults": Object {
     "a": "false",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": false,
@@ -15248,29 +9038,7 @@ Object {
 }
 `;
 
-exports[`#374 - espree.parse - function namedFn (...restArgs) {return 321} 1`] = `
-Object {
-  "args": Array [
-    "restArgs",
-  ],
-  "body": "return 321",
-  "defaults": Object {
-    "restArgs": undefined,
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "restArgs",
-  "value": "(function namedFn (...restArgs) {return 321})",
-}
-`;
-
-exports[`#375 - espree.parse - function (a = (true, null)) {} 1`] = `
+exports[`#395 - espree.parse - function (a = (true, null)) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -15279,6 +9047,7 @@ Object {
   "defaults": Object {
     "a": "null",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": false,
@@ -15292,25 +9061,7 @@ Object {
 }
 `;
 
-exports[`#375 - espree.parse - function namedFn () {} 1`] = `
-Object {
-  "args": Array [],
-  "body": "",
-  "defaults": Object {},
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "",
-  "value": "(function namedFn () {})",
-}
-`;
-
-exports[`#376 - espree.parse - function (a = (true, "bar")) {} 1`] = `
+exports[`#396 - espree.parse - function (a = (true, "bar")) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -15319,6 +9070,7 @@ Object {
   "defaults": Object {
     "a": "\\"bar\\"",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": false,
@@ -15332,29 +9084,7 @@ Object {
 }
 `;
 
-exports[`#376 - espree.parse - function namedFn(a = (true, false)) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "false",
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "a",
-  "value": "(function namedFn(a = (true, false)) {})",
-}
-`;
-
-exports[`#377 - espree.parse - function (a, b = (i++, true)) {} 1`] = `
+exports[`#397 - espree.parse - function (a, b = (i++, true)) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -15365,6 +9095,7 @@ Object {
     "a": undefined,
     "b": "true",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": false,
@@ -15378,29 +9109,7 @@ Object {
 }
 `;
 
-exports[`#377 - espree.parse - function namedFn(a = (true, null)) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "null",
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "a",
-  "value": "(function namedFn(a = (true, null)) {})",
-}
-`;
-
-exports[`#378 - espree.parse - function (a = 1) {} 1`] = `
+exports[`#398 - espree.parse - function (a = 1) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -15409,6 +9118,7 @@ Object {
   "defaults": Object {
     "a": "1",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": false,
@@ -15422,29 +9132,33 @@ Object {
 }
 `;
 
-exports[`#378 - espree.parse - function namedFn(a = (true, "bar")) {} 1`] = `
+exports[`#399 - espree.parse - function ({x, y}) {} 1`] = `
 Object {
   "args": Array [
-    "a",
+    false,
   ],
   "body": "",
   "defaults": Object {
-    "a": "\\"bar\\"",
+    "false": undefined,
   },
-  "isAnonymous": false,
+  "destructuredArgs": Array [
+    "x",
+    "y",
+  ],
+  "isAnonymous": true,
   "isArrow": false,
   "isAsync": false,
   "isExpression": false,
   "isGenerator": false,
-  "isNamed": true,
+  "isNamed": false,
   "isValid": true,
-  "name": "namedFn",
-  "params": "a",
-  "value": "(function namedFn(a = (true, \\"bar\\")) {})",
+  "name": null,
+  "params": "false",
+  "value": "(function ({x, y}) {})",
 }
 `;
 
-exports[`#379 - espree.parse - function namedFn (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
+exports[`#400 - espree.parse - function namedFn (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -15457,6 +9171,7 @@ Object {
     "cb": undefined,
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -15470,31 +9185,7 @@ Object {
 }
 `;
 
-exports[`#379 - espree.parse - function namedFn(a, b = (i++, true)) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-    "b",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": undefined,
-    "b": "true",
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "a, b",
-  "value": "(function namedFn(a, b = (i++, true)) {})",
-}
-`;
-
-exports[`#380 - espree.parse - function namedFn (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
+exports[`#401 - espree.parse - function namedFn (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
 Object {
   "args": Array [
     "b",
@@ -15507,6 +9198,7 @@ Object {
     "callback": undefined,
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -15520,55 +9212,7 @@ Object {
 }
 `;
 
-exports[`#380 - espree.parse - function namedFn(a = 1) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "1",
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "a",
-  "value": "(function namedFn(a = 1) {})",
-}
-`;
-
-exports[`#381 - espree.parse - function * namedFn (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
-Object {
-  "args": Array [
-    "a",
-    "cb",
-    "restArgs",
-  ],
-  "body": "return a * 3",
-  "defaults": Object {
-    "a": "{foo: \\"ba)r\\", baz: 123}",
-    "cb": undefined,
-    "restArgs": undefined,
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": true,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "a, cb, restArgs",
-  "value": "(function * namedFn (a = {foo: \\"ba)r\\", baz: 123}, cb, ...restArgs) {return a * 3})",
-}
-`;
-
-exports[`#381 - espree.parse - function namedFn (c) {return c * 3} 1`] = `
+exports[`#402 - espree.parse - function namedFn (c) {return c * 3} 1`] = `
 Object {
   "args": Array [
     "c",
@@ -15577,6 +9221,7 @@ Object {
   "defaults": Object {
     "c": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -15590,33 +9235,7 @@ Object {
 }
 `;
 
-exports[`#382 - espree.parse - function * namedFn (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
-Object {
-  "args": Array [
-    "b",
-    "callback",
-    "restArgs",
-  ],
-  "body": "callback(null, b + 3)",
-  "defaults": Object {
-    "b": undefined,
-    "callback": undefined,
-    "restArgs": undefined,
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": true,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "b, callback, restArgs",
-  "value": "(function * namedFn (b, callback, ...restArgs) {callback(null, b + 3)})",
-}
-`;
-
-exports[`#382 - espree.parse - function namedFn (...restArgs) {return 321} 1`] = `
+exports[`#403 - espree.parse - function namedFn (...restArgs) {return 321} 1`] = `
 Object {
   "args": Array [
     "restArgs",
@@ -15625,6 +9244,7 @@ Object {
   "defaults": Object {
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -15638,33 +9258,12 @@ Object {
 }
 `;
 
-exports[`#383 - espree.parse - function * namedFn (c) {return c * 3} 1`] = `
-Object {
-  "args": Array [
-    "c",
-  ],
-  "body": "return c * 3",
-  "defaults": Object {
-    "c": undefined,
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": true,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "c",
-  "value": "(function * namedFn (c) {return c * 3})",
-}
-`;
-
-exports[`#383 - espree.parse - function namedFn () {} 1`] = `
+exports[`#404 - espree.parse - function namedFn () {} 1`] = `
 Object {
   "args": Array [],
   "body": "",
   "defaults": Object {},
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -15678,29 +9277,7 @@ Object {
 }
 `;
 
-exports[`#384 - espree.parse - function * namedFn (...restArgs) {return 321} 1`] = `
-Object {
-  "args": Array [
-    "restArgs",
-  ],
-  "body": "return 321",
-  "defaults": Object {
-    "restArgs": undefined,
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": true,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "restArgs",
-  "value": "(function * namedFn (...restArgs) {return 321})",
-}
-`;
-
-exports[`#384 - espree.parse - function namedFn(a = (true, false)) {} 1`] = `
+exports[`#405 - espree.parse - function namedFn(a = (true, false)) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -15709,6 +9286,7 @@ Object {
   "defaults": Object {
     "a": "false",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -15722,25 +9300,7 @@ Object {
 }
 `;
 
-exports[`#385 - espree.parse - function * namedFn () {} 1`] = `
-Object {
-  "args": Array [],
-  "body": "",
-  "defaults": Object {},
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": true,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "",
-  "value": "(function * namedFn () {})",
-}
-`;
-
-exports[`#385 - espree.parse - function namedFn(a = (true, null)) {} 1`] = `
+exports[`#406 - espree.parse - function namedFn(a = (true, null)) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -15749,6 +9309,7 @@ Object {
   "defaults": Object {
     "a": "null",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -15762,29 +9323,7 @@ Object {
 }
 `;
 
-exports[`#386 - espree.parse - function * namedFn(a = (true, false)) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "false",
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": true,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "a",
-  "value": "(function * namedFn(a = (true, false)) {})",
-}
-`;
-
-exports[`#386 - espree.parse - function namedFn(a = (true, "bar")) {} 1`] = `
+exports[`#407 - espree.parse - function namedFn(a = (true, "bar")) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -15793,6 +9332,7 @@ Object {
   "defaults": Object {
     "a": "\\"bar\\"",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -15806,29 +9346,7 @@ Object {
 }
 `;
 
-exports[`#387 - espree.parse - function * namedFn(a = (true, null)) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "null",
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": true,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "a",
-  "value": "(function * namedFn(a = (true, null)) {})",
-}
-`;
-
-exports[`#387 - espree.parse - function namedFn(a, b = (i++, true)) {} 1`] = `
+exports[`#408 - espree.parse - function namedFn(a, b = (i++, true)) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -15839,6 +9357,7 @@ Object {
     "a": undefined,
     "b": "true",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -15852,29 +9371,7 @@ Object {
 }
 `;
 
-exports[`#388 - espree.parse - function * namedFn(a = (true, "bar")) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "\\"bar\\"",
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": true,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "a",
-  "value": "(function * namedFn(a = (true, \\"bar\\")) {})",
-}
-`;
-
-exports[`#388 - espree.parse - function namedFn(a = 1) {} 1`] = `
+exports[`#409 - espree.parse - function namedFn(a = 1) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -15883,6 +9380,7 @@ Object {
   "defaults": Object {
     "a": "1",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -15896,7 +9394,33 @@ Object {
 }
 `;
 
-exports[`#389 - espree.parse - function * namedFn (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
+exports[`#410 - espree.parse - function namedFn({x, y}) {} 1`] = `
+Object {
+  "args": Array [
+    false,
+  ],
+  "body": "",
+  "defaults": Object {
+    "false": undefined,
+  },
+  "destructuredArgs": Array [
+    "x",
+    "y",
+  ],
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "false",
+  "value": "(function namedFn({x, y}) {})",
+}
+`;
+
+exports[`#411 - espree.parse - function * namedFn (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -15909,6 +9433,7 @@ Object {
     "cb": undefined,
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -15922,31 +9447,7 @@ Object {
 }
 `;
 
-exports[`#389 - espree.parse - function * namedFn(a, b = (i++, true)) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-    "b",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": undefined,
-    "b": "true",
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": true,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "a, b",
-  "value": "(function * namedFn(a, b = (i++, true)) {})",
-}
-`;
-
-exports[`#390 - espree.parse - function * namedFn (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
+exports[`#412 - espree.parse - function * namedFn (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
 Object {
   "args": Array [
     "b",
@@ -15959,6 +9460,7 @@ Object {
     "callback": undefined,
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -15972,55 +9474,7 @@ Object {
 }
 `;
 
-exports[`#390 - espree.parse - function * namedFn(a = 1) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "1",
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": true,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "a",
-  "value": "(function * namedFn(a = 1) {})",
-}
-`;
-
-exports[`#391 - espree.parse - (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) => {return a * 3} 1`] = `
-Object {
-  "args": Array [
-    "a",
-    "cb",
-    "restArgs",
-  ],
-  "body": "return a * 3",
-  "defaults": Object {
-    "a": "{foo: \\"ba)r\\", baz: 123}",
-    "cb": undefined,
-    "restArgs": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a, cb, restArgs",
-  "value": "((a = {foo: \\"ba)r\\", baz: 123}, cb, ...restArgs) => {return a * 3})",
-}
-`;
-
-exports[`#391 - espree.parse - function * namedFn (c) {return c * 3} 1`] = `
+exports[`#413 - espree.parse - function * namedFn (c) {return c * 3} 1`] = `
 Object {
   "args": Array [
     "c",
@@ -16029,6 +9483,7 @@ Object {
   "defaults": Object {
     "c": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -16042,33 +9497,7 @@ Object {
 }
 `;
 
-exports[`#392 - espree.parse - (b, callback, ...restArgs) => {callback(null, b + 3)} 1`] = `
-Object {
-  "args": Array [
-    "b",
-    "callback",
-    "restArgs",
-  ],
-  "body": "callback(null, b + 3)",
-  "defaults": Object {
-    "b": undefined,
-    "callback": undefined,
-    "restArgs": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "b, callback, restArgs",
-  "value": "((b, callback, ...restArgs) => {callback(null, b + 3)})",
-}
-`;
-
-exports[`#392 - espree.parse - function * namedFn (...restArgs) {return 321} 1`] = `
+exports[`#414 - espree.parse - function * namedFn (...restArgs) {return 321} 1`] = `
 Object {
   "args": Array [
     "restArgs",
@@ -16077,6 +9506,7 @@ Object {
   "defaults": Object {
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -16090,33 +9520,12 @@ Object {
 }
 `;
 
-exports[`#393 - espree.parse - (c) => {return c * 3} 1`] = `
-Object {
-  "args": Array [
-    "c",
-  ],
-  "body": "return c * 3",
-  "defaults": Object {
-    "c": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "c",
-  "value": "((c) => {return c * 3})",
-}
-`;
-
-exports[`#393 - espree.parse - function * namedFn () {} 1`] = `
+exports[`#415 - espree.parse - function * namedFn () {} 1`] = `
 Object {
   "args": Array [],
   "body": "",
   "defaults": Object {},
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -16130,29 +9539,7 @@ Object {
 }
 `;
 
-exports[`#394 - espree.parse - (...restArgs) => {return 321} 1`] = `
-Object {
-  "args": Array [
-    "restArgs",
-  ],
-  "body": "return 321",
-  "defaults": Object {
-    "restArgs": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "restArgs",
-  "value": "((...restArgs) => {return 321})",
-}
-`;
-
-exports[`#394 - espree.parse - function * namedFn(a = (true, false)) {} 1`] = `
+exports[`#416 - espree.parse - function * namedFn(a = (true, false)) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -16161,6 +9548,7 @@ Object {
   "defaults": Object {
     "a": "false",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -16174,25 +9562,7 @@ Object {
 }
 `;
 
-exports[`#395 - espree.parse - () => {} 1`] = `
-Object {
-  "args": Array [],
-  "body": "",
-  "defaults": Object {},
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "",
-  "value": "(() => {})",
-}
-`;
-
-exports[`#395 - espree.parse - function * namedFn(a = (true, null)) {} 1`] = `
+exports[`#417 - espree.parse - function * namedFn(a = (true, null)) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -16201,6 +9571,7 @@ Object {
   "defaults": Object {
     "a": "null",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -16214,29 +9585,7 @@ Object {
 }
 `;
 
-exports[`#396 - espree.parse - (a = (true, false)) => {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "false",
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "((a = (true, false)) => {})",
-}
-`;
-
-exports[`#396 - espree.parse - function * namedFn(a = (true, "bar")) {} 1`] = `
+exports[`#418 - espree.parse - function * namedFn(a = (true, "bar")) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -16245,6 +9594,7 @@ Object {
   "defaults": Object {
     "a": "\\"bar\\"",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -16258,29 +9608,7 @@ Object {
 }
 `;
 
-exports[`#397 - espree.parse - (a = (true, null)) => {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "null",
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "((a = (true, null)) => {})",
-}
-`;
-
-exports[`#397 - espree.parse - function * namedFn(a, b = (i++, true)) {} 1`] = `
+exports[`#419 - espree.parse - function * namedFn(a, b = (i++, true)) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -16291,6 +9619,7 @@ Object {
     "a": undefined,
     "b": "true",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -16304,29 +9633,7 @@ Object {
 }
 `;
 
-exports[`#398 - espree.parse - (a = (true, "bar")) => {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "\\"bar\\"",
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "((a = (true, \\"bar\\")) => {})",
-}
-`;
-
-exports[`#398 - espree.parse - function * namedFn(a = 1) {} 1`] = `
+exports[`#420 - espree.parse - function * namedFn(a = 1) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -16335,6 +9642,7 @@ Object {
   "defaults": Object {
     "a": "1",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -16348,7 +9656,33 @@ Object {
 }
 `;
 
-exports[`#399 - espree.parse - (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) => {return a * 3} 1`] = `
+exports[`#421 - espree.parse - function * namedFn({x, y}) {} 1`] = `
+Object {
+  "args": Array [
+    false,
+  ],
+  "body": "",
+  "defaults": Object {
+    "false": undefined,
+  },
+  "destructuredArgs": Array [
+    "x",
+    "y",
+  ],
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": true,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "false",
+  "value": "(function * namedFn({x, y}) {})",
+}
+`;
+
+exports[`#422 - espree.parse - (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) => {return a * 3} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -16361,6 +9695,7 @@ Object {
     "cb": undefined,
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -16374,53 +9709,7 @@ Object {
 }
 `;
 
-exports[`#399 - espree.parse - (a, b = (i++, true)) => {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-    "b",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": undefined,
-    "b": "true",
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a, b",
-  "value": "((a, b = (i++, true)) => {})",
-}
-`;
-
-exports[`#400 - espree.parse - (a = 1) => {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "1",
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "((a = 1) => {})",
-}
-`;
-
-exports[`#400 - espree.parse - (b, callback, ...restArgs) => {callback(null, b + 3)} 1`] = `
+exports[`#423 - espree.parse - (b, callback, ...restArgs) => {callback(null, b + 3)} 1`] = `
 Object {
   "args": Array [
     "b",
@@ -16433,6 +9722,7 @@ Object {
     "callback": undefined,
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -16446,29 +9736,7 @@ Object {
 }
 `;
 
-exports[`#401 - espree.parse - (a) => a * 3 * a 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "a * 3 * a",
-  "defaults": Object {
-    "a": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": false,
-  "isExpression": true,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "((a) => a * 3 * a)",
-}
-`;
-
-exports[`#401 - espree.parse - (c) => {return c * 3} 1`] = `
+exports[`#424 - espree.parse - (c) => {return c * 3} 1`] = `
 Object {
   "args": Array [
     "c",
@@ -16477,6 +9745,7 @@ Object {
   "defaults": Object {
     "c": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -16490,7 +9759,7 @@ Object {
 }
 `;
 
-exports[`#402 - espree.parse - (...restArgs) => {return 321} 1`] = `
+exports[`#425 - espree.parse - (...restArgs) => {return 321} 1`] = `
 Object {
   "args": Array [
     "restArgs",
@@ -16499,6 +9768,7 @@ Object {
   "defaults": Object {
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -16512,33 +9782,12 @@ Object {
 }
 `;
 
-exports[`#402 - espree.parse - d => d * 355 * d 1`] = `
-Object {
-  "args": Array [
-    "d",
-  ],
-  "body": "d * 355 * d",
-  "defaults": Object {
-    "d": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": false,
-  "isExpression": true,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "d",
-  "value": "(d => d * 355 * d)",
-}
-`;
-
-exports[`#403 - espree.parse - () => {} 1`] = `
+exports[`#426 - espree.parse - () => {} 1`] = `
 Object {
   "args": Array [],
   "body": "",
   "defaults": Object {},
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -16552,29 +9801,7 @@ Object {
 }
 `;
 
-exports[`#403 - espree.parse - e => {return e + 5235 / e} 1`] = `
-Object {
-  "args": Array [
-    "e",
-  ],
-  "body": "return e + 5235 / e",
-  "defaults": Object {
-    "e": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "e",
-  "value": "(e => {return e + 5235 / e})",
-}
-`;
-
-exports[`#404 - espree.parse - (a = (true, false)) => {} 1`] = `
+exports[`#427 - espree.parse - (a = (true, false)) => {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -16583,6 +9810,7 @@ Object {
   "defaults": Object {
     "a": "false",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -16596,31 +9824,7 @@ Object {
 }
 `;
 
-exports[`#404 - espree.parse - (a, b) => a + 3 + b 1`] = `
-Object {
-  "args": Array [
-    "a",
-    "b",
-  ],
-  "body": "a + 3 + b",
-  "defaults": Object {
-    "a": undefined,
-    "b": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": false,
-  "isExpression": true,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a, b",
-  "value": "((a, b) => a + 3 + b)",
-}
-`;
-
-exports[`#405 - espree.parse - (a = (true, null)) => {} 1`] = `
+exports[`#428 - espree.parse - (a = (true, null)) => {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -16629,6 +9833,7 @@ Object {
   "defaults": Object {
     "a": "null",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -16642,33 +9847,7 @@ Object {
 }
 `;
 
-exports[`#405 - espree.parse - (x, y, ...restArgs) => console.log({ value: x * y }) 1`] = `
-Object {
-  "args": Array [
-    "x",
-    "y",
-    "restArgs",
-  ],
-  "body": "console.log({ value: x * y })",
-  "defaults": Object {
-    "restArgs": undefined,
-    "x": undefined,
-    "y": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": false,
-  "isExpression": true,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "x, y, restArgs",
-  "value": "((x, y, ...restArgs) => console.log({ value: x * y }))",
-}
-`;
-
-exports[`#406 - espree.parse - (a = (true, "bar")) => {} 1`] = `
+exports[`#429 - espree.parse - (a = (true, "bar")) => {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -16677,6 +9856,7 @@ Object {
   "defaults": Object {
     "a": "\\"bar\\"",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -16690,33 +9870,7 @@ Object {
 }
 `;
 
-exports[`#406 - espree.parse - async function (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
-Object {
-  "args": Array [
-    "a",
-    "cb",
-    "restArgs",
-  ],
-  "body": "return a * 3",
-  "defaults": Object {
-    "a": "{foo: \\"ba)r\\", baz: 123}",
-    "cb": undefined,
-    "restArgs": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a, cb, restArgs",
-  "value": "(async function (a = {foo: \\"ba)r\\", baz: 123}, cb, ...restArgs) {return a * 3})",
-}
-`;
-
-exports[`#407 - espree.parse - (a, b = (i++, true)) => {} 1`] = `
+exports[`#430 - espree.parse - (a, b = (i++, true)) => {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -16727,6 +9881,7 @@ Object {
     "a": undefined,
     "b": "true",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -16740,33 +9895,7 @@ Object {
 }
 `;
 
-exports[`#407 - espree.parse - async function (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
-Object {
-  "args": Array [
-    "b",
-    "callback",
-    "restArgs",
-  ],
-  "body": "callback(null, b + 3)",
-  "defaults": Object {
-    "b": undefined,
-    "callback": undefined,
-    "restArgs": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "b, callback, restArgs",
-  "value": "(async function (b, callback, ...restArgs) {callback(null, b + 3)})",
-}
-`;
-
-exports[`#408 - espree.parse - (a = 1) => {} 1`] = `
+exports[`#431 - espree.parse - (a = 1) => {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -16775,6 +9904,7 @@ Object {
   "defaults": Object {
     "a": "1",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -16788,29 +9918,7 @@ Object {
 }
 `;
 
-exports[`#408 - espree.parse - async function (c) {return c * 3} 1`] = `
-Object {
-  "args": Array [
-    "c",
-  ],
-  "body": "return c * 3",
-  "defaults": Object {
-    "c": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "c",
-  "value": "(async function (c) {return c * 3})",
-}
-`;
-
-exports[`#409 - espree.parse - (a) => a * 3 * a 1`] = `
+exports[`#432 - espree.parse - (a) => a * 3 * a 1`] = `
 Object {
   "args": Array [
     "a",
@@ -16819,6 +9927,7 @@ Object {
   "defaults": Object {
     "a": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -16832,47 +9941,7 @@ Object {
 }
 `;
 
-exports[`#409 - espree.parse - async function (...restArgs) {return 321} 1`] = `
-Object {
-  "args": Array [
-    "restArgs",
-  ],
-  "body": "return 321",
-  "defaults": Object {
-    "restArgs": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "restArgs",
-  "value": "(async function (...restArgs) {return 321})",
-}
-`;
-
-exports[`#410 - espree.parse - async function () {} 1`] = `
-Object {
-  "args": Array [],
-  "body": "",
-  "defaults": Object {},
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "",
-  "value": "(async function () {})",
-}
-`;
-
-exports[`#410 - espree.parse - d => d * 355 * d 1`] = `
+exports[`#433 - espree.parse - d => d * 355 * d 1`] = `
 Object {
   "args": Array [
     "d",
@@ -16881,6 +9950,7 @@ Object {
   "defaults": Object {
     "d": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -16894,29 +9964,7 @@ Object {
 }
 `;
 
-exports[`#411 - espree.parse - async function (a = (true, false)) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "false",
-  },
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "(async function (a = (true, false)) {})",
-}
-`;
-
-exports[`#411 - espree.parse - e => {return e + 5235 / e} 1`] = `
+exports[`#434 - espree.parse - e => {return e + 5235 / e} 1`] = `
 Object {
   "args": Array [
     "e",
@@ -16925,6 +9973,7 @@ Object {
   "defaults": Object {
     "e": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -16938,7 +9987,7 @@ Object {
 }
 `;
 
-exports[`#412 - espree.parse - (a, b) => a + 3 + b 1`] = `
+exports[`#435 - espree.parse - (a, b) => a + 3 + b 1`] = `
 Object {
   "args": Array [
     "a",
@@ -16949,6 +9998,7 @@ Object {
     "a": undefined,
     "b": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -16962,29 +10012,7 @@ Object {
 }
 `;
 
-exports[`#412 - espree.parse - async function (a = (true, null)) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "null",
-  },
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "(async function (a = (true, null)) {})",
-}
-`;
-
-exports[`#413 - espree.parse - (x, y, ...restArgs) => console.log({ value: x * y }) 1`] = `
+exports[`#436 - espree.parse - (x, y, ...restArgs) => console.log({ value: x * y }) 1`] = `
 Object {
   "args": Array [
     "x",
@@ -16997,6 +10025,7 @@ Object {
     "x": undefined,
     "y": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -17010,36 +10039,19 @@ Object {
 }
 `;
 
-exports[`#413 - espree.parse - async function (a = (true, "bar")) {} 1`] = `
+exports[`#437 - espree.parse - ({x, y}) => {} 1`] = `
 Object {
   "args": Array [
-    "a",
+    false,
   ],
   "body": "",
   "defaults": Object {
-    "a": "\\"bar\\"",
+    "false": undefined,
   },
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "(async function (a = (true, \\"bar\\")) {})",
-}
-`;
-
-exports[`#414 - espree.parse - ({x, y}) => {} 1`] = `
-Object {
-  "args": Array [
+  "destructuredArgs": Array [
     "x",
     "y",
   ],
-  "body": "",
-  "defaults": Object {},
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": false,
@@ -17048,36 +10060,12 @@ Object {
   "isNamed": false,
   "isValid": true,
   "name": null,
-  "params": "x, y",
+  "params": "false",
   "value": "(({x, y}) => {})",
 }
 `;
 
-exports[`#414 - espree.parse - async function (a, b = (i++, true)) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-    "b",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": undefined,
-    "b": "true",
-  },
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a, b",
-  "value": "(async function (a, b = (i++, true)) {})",
-}
-`;
-
-exports[`#415 - espree.parse - async function (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
+exports[`#438 - espree.parse - async function (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -17090,6 +10078,7 @@ Object {
     "cb": undefined,
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": true,
@@ -17103,29 +10092,7 @@ Object {
 }
 `;
 
-exports[`#415 - espree.parse - async function (a = 1) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "1",
-  },
-  "isAnonymous": true,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "(async function (a = 1) {})",
-}
-`;
-
-exports[`#416 - espree.parse - async function (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
+exports[`#439 - espree.parse - async function (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
 Object {
   "args": Array [
     "b",
@@ -17138,6 +10105,7 @@ Object {
     "callback": undefined,
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": true,
@@ -17151,33 +10119,7 @@ Object {
 }
 `;
 
-exports[`#416 - espree.parse - async function namedFn (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
-Object {
-  "args": Array [
-    "a",
-    "cb",
-    "restArgs",
-  ],
-  "body": "return a * 3",
-  "defaults": Object {
-    "a": "{foo: \\"ba)r\\", baz: 123}",
-    "cb": undefined,
-    "restArgs": undefined,
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "a, cb, restArgs",
-  "value": "(async function namedFn (a = {foo: \\"ba)r\\", baz: 123}, cb, ...restArgs) {return a * 3})",
-}
-`;
-
-exports[`#417 - espree.parse - async function (c) {return c * 3} 1`] = `
+exports[`#440 - espree.parse - async function (c) {return c * 3} 1`] = `
 Object {
   "args": Array [
     "c",
@@ -17186,6 +10128,7 @@ Object {
   "defaults": Object {
     "c": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": true,
@@ -17199,33 +10142,7 @@ Object {
 }
 `;
 
-exports[`#417 - espree.parse - async function namedFn (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
-Object {
-  "args": Array [
-    "b",
-    "callback",
-    "restArgs",
-  ],
-  "body": "callback(null, b + 3)",
-  "defaults": Object {
-    "b": undefined,
-    "callback": undefined,
-    "restArgs": undefined,
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "b, callback, restArgs",
-  "value": "(async function namedFn (b, callback, ...restArgs) {callback(null, b + 3)})",
-}
-`;
-
-exports[`#418 - espree.parse - async function (...restArgs) {return 321} 1`] = `
+exports[`#441 - espree.parse - async function (...restArgs) {return 321} 1`] = `
 Object {
   "args": Array [
     "restArgs",
@@ -17234,6 +10151,7 @@ Object {
   "defaults": Object {
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": true,
@@ -17247,33 +10165,12 @@ Object {
 }
 `;
 
-exports[`#418 - espree.parse - async function namedFn (c) {return c * 3} 1`] = `
-Object {
-  "args": Array [
-    "c",
-  ],
-  "body": "return c * 3",
-  "defaults": Object {
-    "c": undefined,
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "c",
-  "value": "(async function namedFn (c) {return c * 3})",
-}
-`;
-
-exports[`#419 - espree.parse - async function () {} 1`] = `
+exports[`#442 - espree.parse - async function () {} 1`] = `
 Object {
   "args": Array [],
   "body": "",
   "defaults": Object {},
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": true,
@@ -17287,29 +10184,7 @@ Object {
 }
 `;
 
-exports[`#419 - espree.parse - async function namedFn (...restArgs) {return 321} 1`] = `
-Object {
-  "args": Array [
-    "restArgs",
-  ],
-  "body": "return 321",
-  "defaults": Object {
-    "restArgs": undefined,
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "restArgs",
-  "value": "(async function namedFn (...restArgs) {return 321})",
-}
-`;
-
-exports[`#420 - espree.parse - async function (a = (true, false)) {} 1`] = `
+exports[`#443 - espree.parse - async function (a = (true, false)) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -17318,6 +10193,7 @@ Object {
   "defaults": Object {
     "a": "false",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": true,
@@ -17331,25 +10207,7 @@ Object {
 }
 `;
 
-exports[`#420 - espree.parse - async function namedFn () {} 1`] = `
-Object {
-  "args": Array [],
-  "body": "",
-  "defaults": Object {},
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "",
-  "value": "(async function namedFn () {})",
-}
-`;
-
-exports[`#421 - espree.parse - async function (a = (true, null)) {} 1`] = `
+exports[`#444 - espree.parse - async function (a = (true, null)) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -17358,6 +10216,7 @@ Object {
   "defaults": Object {
     "a": "null",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": true,
@@ -17371,29 +10230,7 @@ Object {
 }
 `;
 
-exports[`#421 - espree.parse - async function namedFn(a = (true, false)) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "false",
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "a",
-  "value": "(async function namedFn(a = (true, false)) {})",
-}
-`;
-
-exports[`#422 - espree.parse - async function (a = (true, "bar")) {} 1`] = `
+exports[`#445 - espree.parse - async function (a = (true, "bar")) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -17402,6 +10239,7 @@ Object {
   "defaults": Object {
     "a": "\\"bar\\"",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": true,
@@ -17415,29 +10253,7 @@ Object {
 }
 `;
 
-exports[`#422 - espree.parse - async function namedFn(a = (true, null)) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "null",
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "a",
-  "value": "(async function namedFn(a = (true, null)) {})",
-}
-`;
-
-exports[`#423 - espree.parse - async function (a, b = (i++, true)) {} 1`] = `
+exports[`#446 - espree.parse - async function (a, b = (i++, true)) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -17448,6 +10264,7 @@ Object {
     "a": undefined,
     "b": "true",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": true,
@@ -17461,29 +10278,7 @@ Object {
 }
 `;
 
-exports[`#423 - espree.parse - async function namedFn(a = (true, "bar")) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "\\"bar\\"",
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "a",
-  "value": "(async function namedFn(a = (true, \\"bar\\")) {})",
-}
-`;
-
-exports[`#424 - espree.parse - async function (a = 1) {} 1`] = `
+exports[`#447 - espree.parse - async function (a = 1) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -17492,6 +10287,7 @@ Object {
   "defaults": Object {
     "a": "1",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": false,
   "isAsync": true,
@@ -17505,31 +10301,33 @@ Object {
 }
 `;
 
-exports[`#424 - espree.parse - async function namedFn(a, b = (i++, true)) {} 1`] = `
+exports[`#448 - espree.parse - async function ({x, y}) {} 1`] = `
 Object {
   "args": Array [
-    "a",
-    "b",
+    false,
   ],
   "body": "",
   "defaults": Object {
-    "a": undefined,
-    "b": "true",
+    "false": undefined,
   },
-  "isAnonymous": false,
+  "destructuredArgs": Array [
+    "x",
+    "y",
+  ],
+  "isAnonymous": true,
   "isArrow": false,
   "isAsync": true,
   "isExpression": false,
   "isGenerator": false,
-  "isNamed": true,
+  "isNamed": false,
   "isValid": true,
-  "name": "namedFn",
-  "params": "a, b",
-  "value": "(async function namedFn(a, b = (i++, true)) {})",
+  "name": null,
+  "params": "false",
+  "value": "(async function ({x, y}) {})",
 }
 `;
 
-exports[`#425 - espree.parse - async function namedFn (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
+exports[`#449 - espree.parse - async function namedFn (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -17542,6 +10340,7 @@ Object {
     "cb": undefined,
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": true,
@@ -17555,55 +10354,7 @@ Object {
 }
 `;
 
-exports[`#425 - espree.parse - async function namedFn(a = 1) {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "1",
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "a",
-  "value": "(async function namedFn(a = 1) {})",
-}
-`;
-
-exports[`#426 - espree.parse - async (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) => {return a * 3} 1`] = `
-Object {
-  "args": Array [
-    "a",
-    "cb",
-    "restArgs",
-  ],
-  "body": "return a * 3",
-  "defaults": Object {
-    "a": "{foo: \\"ba)r\\", baz: 123}",
-    "cb": undefined,
-    "restArgs": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a, cb, restArgs",
-  "value": "(async (a = {foo: \\"ba)r\\", baz: 123}, cb, ...restArgs) => {return a * 3})",
-}
-`;
-
-exports[`#426 - espree.parse - async function namedFn (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
+exports[`#450 - espree.parse - async function namedFn (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
 Object {
   "args": Array [
     "b",
@@ -17616,6 +10367,7 @@ Object {
     "callback": undefined,
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": true,
@@ -17629,33 +10381,7 @@ Object {
 }
 `;
 
-exports[`#427 - espree.parse - async (b, callback, ...restArgs) => {callback(null, b + 3)} 1`] = `
-Object {
-  "args": Array [
-    "b",
-    "callback",
-    "restArgs",
-  ],
-  "body": "callback(null, b + 3)",
-  "defaults": Object {
-    "b": undefined,
-    "callback": undefined,
-    "restArgs": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "b, callback, restArgs",
-  "value": "(async (b, callback, ...restArgs) => {callback(null, b + 3)})",
-}
-`;
-
-exports[`#427 - espree.parse - async function namedFn (c) {return c * 3} 1`] = `
+exports[`#451 - espree.parse - async function namedFn (c) {return c * 3} 1`] = `
 Object {
   "args": Array [
     "c",
@@ -17664,6 +10390,7 @@ Object {
   "defaults": Object {
     "c": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": true,
@@ -17677,29 +10404,7 @@ Object {
 }
 `;
 
-exports[`#428 - espree.parse - async (c) => {return c * 3} 1`] = `
-Object {
-  "args": Array [
-    "c",
-  ],
-  "body": "return c * 3",
-  "defaults": Object {
-    "c": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "c",
-  "value": "(async (c) => {return c * 3})",
-}
-`;
-
-exports[`#428 - espree.parse - async function namedFn (...restArgs) {return 321} 1`] = `
+exports[`#452 - espree.parse - async function namedFn (...restArgs) {return 321} 1`] = `
 Object {
   "args": Array [
     "restArgs",
@@ -17708,6 +10413,7 @@ Object {
   "defaults": Object {
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": true,
@@ -17721,33 +10427,12 @@ Object {
 }
 `;
 
-exports[`#429 - espree.parse - async (...restArgs) => {return 321} 1`] = `
-Object {
-  "args": Array [
-    "restArgs",
-  ],
-  "body": "return 321",
-  "defaults": Object {
-    "restArgs": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "restArgs",
-  "value": "(async (...restArgs) => {return 321})",
-}
-`;
-
-exports[`#429 - espree.parse - async function namedFn () {} 1`] = `
+exports[`#453 - espree.parse - async function namedFn () {} 1`] = `
 Object {
   "args": Array [],
   "body": "",
   "defaults": Object {},
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": true,
@@ -17761,25 +10446,7 @@ Object {
 }
 `;
 
-exports[`#430 - espree.parse - async () => {} 1`] = `
-Object {
-  "args": Array [],
-  "body": "",
-  "defaults": Object {},
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "",
-  "value": "(async () => {})",
-}
-`;
-
-exports[`#430 - espree.parse - async function namedFn(a = (true, false)) {} 1`] = `
+exports[`#454 - espree.parse - async function namedFn(a = (true, false)) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -17788,6 +10455,7 @@ Object {
   "defaults": Object {
     "a": "false",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": true,
@@ -17801,29 +10469,7 @@ Object {
 }
 `;
 
-exports[`#431 - espree.parse - async (a = (true, false)) => {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "false",
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "(async (a = (true, false)) => {})",
-}
-`;
-
-exports[`#431 - espree.parse - async function namedFn(a = (true, null)) {} 1`] = `
+exports[`#455 - espree.parse - async function namedFn(a = (true, null)) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -17832,6 +10478,7 @@ Object {
   "defaults": Object {
     "a": "null",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": true,
@@ -17845,29 +10492,7 @@ Object {
 }
 `;
 
-exports[`#432 - espree.parse - async (a = (true, null)) => {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "null",
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "(async (a = (true, null)) => {})",
-}
-`;
-
-exports[`#432 - espree.parse - async function namedFn(a = (true, "bar")) {} 1`] = `
+exports[`#456 - espree.parse - async function namedFn(a = (true, "bar")) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -17876,6 +10501,7 @@ Object {
   "defaults": Object {
     "a": "\\"bar\\"",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": true,
@@ -17889,29 +10515,7 @@ Object {
 }
 `;
 
-exports[`#433 - espree.parse - async (a = (true, "bar")) => {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "\\"bar\\"",
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "(async (a = (true, \\"bar\\")) => {})",
-}
-`;
-
-exports[`#433 - espree.parse - async function namedFn(a, b = (i++, true)) {} 1`] = `
+exports[`#457 - espree.parse - async function namedFn(a, b = (i++, true)) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -17922,6 +10526,7 @@ Object {
     "a": undefined,
     "b": "true",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": true,
@@ -17935,31 +10540,7 @@ Object {
 }
 `;
 
-exports[`#434 - espree.parse - async (a, b = (i++, true)) => {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-    "b",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": undefined,
-    "b": "true",
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a, b",
-  "value": "(async (a, b = (i++, true)) => {})",
-}
-`;
-
-exports[`#434 - espree.parse - async function namedFn(a = 1) {} 1`] = `
+exports[`#458 - espree.parse - async function namedFn(a = 1) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -17968,6 +10549,7 @@ Object {
   "defaults": Object {
     "a": "1",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": true,
@@ -17981,7 +10563,33 @@ Object {
 }
 `;
 
-exports[`#435 - espree.parse - async (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) => {return a * 3} 1`] = `
+exports[`#459 - espree.parse - async function namedFn({x, y}) {} 1`] = `
+Object {
+  "args": Array [
+    false,
+  ],
+  "body": "",
+  "defaults": Object {
+    "false": undefined,
+  },
+  "destructuredArgs": Array [
+    "x",
+    "y",
+  ],
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "false",
+  "value": "(async function namedFn({x, y}) {})",
+}
+`;
+
+exports[`#460 - espree.parse - async (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) => {return a * 3} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -17994,6 +10602,7 @@ Object {
     "cb": undefined,
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -18007,51 +10616,7 @@ Object {
 }
 `;
 
-exports[`#435 - espree.parse - async (a = 1) => {} 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "",
-  "defaults": Object {
-    "a": "1",
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "(async (a = 1) => {})",
-}
-`;
-
-exports[`#436 - espree.parse - async (a) => a * 3 * a 1`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "a * 3 * a",
-  "defaults": Object {
-    "a": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": true,
-  "isExpression": true,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a",
-  "value": "(async (a) => a * 3 * a)",
-}
-`;
-
-exports[`#436 - espree.parse - async (b, callback, ...restArgs) => {callback(null, b + 3)} 1`] = `
+exports[`#461 - espree.parse - async (b, callback, ...restArgs) => {callback(null, b + 3)} 1`] = `
 Object {
   "args": Array [
     "b",
@@ -18064,6 +10629,7 @@ Object {
     "callback": undefined,
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -18077,7 +10643,7 @@ Object {
 }
 `;
 
-exports[`#437 - espree.parse - async (c) => {return c * 3} 1`] = `
+exports[`#462 - espree.parse - async (c) => {return c * 3} 1`] = `
 Object {
   "args": Array [
     "c",
@@ -18086,6 +10652,7 @@ Object {
   "defaults": Object {
     "c": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -18099,29 +10666,7 @@ Object {
 }
 `;
 
-exports[`#437 - espree.parse - async d => d * 355 * d 1`] = `
-Object {
-  "args": Array [
-    "d",
-  ],
-  "body": "d * 355 * d",
-  "defaults": Object {
-    "d": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": true,
-  "isExpression": true,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "d",
-  "value": "(async d => d * 355 * d)",
-}
-`;
-
-exports[`#438 - espree.parse - async (...restArgs) => {return 321} 1`] = `
+exports[`#463 - espree.parse - async (...restArgs) => {return 321} 1`] = `
 Object {
   "args": Array [
     "restArgs",
@@ -18130,6 +10675,7 @@ Object {
   "defaults": Object {
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -18143,33 +10689,12 @@ Object {
 }
 `;
 
-exports[`#438 - espree.parse - async e => {return e + 5235 / e} 1`] = `
-Object {
-  "args": Array [
-    "e",
-  ],
-  "body": "return e + 5235 / e",
-  "defaults": Object {
-    "e": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": true,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "e",
-  "value": "(async e => {return e + 5235 / e})",
-}
-`;
-
-exports[`#439 - espree.parse - async () => {} 1`] = `
+exports[`#464 - espree.parse - async () => {} 1`] = `
 Object {
   "args": Array [],
   "body": "",
   "defaults": Object {},
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -18183,31 +10708,7 @@ Object {
 }
 `;
 
-exports[`#439 - espree.parse - async (a, b) => a + 3 + b 1`] = `
-Object {
-  "args": Array [
-    "a",
-    "b",
-  ],
-  "body": "a + 3 + b",
-  "defaults": Object {
-    "a": undefined,
-    "b": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": true,
-  "isExpression": true,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "a, b",
-  "value": "(async (a, b) => a + 3 + b)",
-}
-`;
-
-exports[`#440 - espree.parse - async (a = (true, false)) => {} 1`] = `
+exports[`#465 - espree.parse - async (a = (true, false)) => {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -18216,6 +10717,7 @@ Object {
   "defaults": Object {
     "a": "false",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -18229,33 +10731,7 @@ Object {
 }
 `;
 
-exports[`#440 - espree.parse - async (x, y, ...restArgs) => console.log({ value: x * y }) 1`] = `
-Object {
-  "args": Array [
-    "x",
-    "y",
-    "restArgs",
-  ],
-  "body": "console.log({ value: x * y })",
-  "defaults": Object {
-    "restArgs": undefined,
-    "x": undefined,
-    "y": undefined,
-  },
-  "isAnonymous": true,
-  "isArrow": true,
-  "isAsync": true,
-  "isExpression": true,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": true,
-  "name": null,
-  "params": "x, y, restArgs",
-  "value": "(async (x, y, ...restArgs) => console.log({ value: x * y }))",
-}
-`;
-
-exports[`#441 - espree.parse - async (a = (true, null)) => {} 1`] = `
+exports[`#466 - espree.parse - async (a = (true, null)) => {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -18264,6 +10740,7 @@ Object {
   "defaults": Object {
     "a": "null",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -18277,25 +10754,7 @@ Object {
 }
 `;
 
-exports[`#441 - espree.parse - should return object with default values when invalid 1`] = `
-Object {
-  "args": Array [],
-  "body": "",
-  "defaults": Object {},
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": false,
-  "name": null,
-  "params": "",
-  "value": "",
-}
-`;
-
-exports[`#442 - espree.parse - async (a = (true, "bar")) => {} 1`] = `
+exports[`#467 - espree.parse - async (a = (true, "bar")) => {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -18304,6 +10763,7 @@ Object {
   "defaults": Object {
     "a": "\\"bar\\"",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -18317,25 +10777,7 @@ Object {
 }
 `;
 
-exports[`#442 - espree.parse - should have '.isValid' and few '.is*'' hidden properties 1`] = `
-Object {
-  "args": Array [],
-  "body": "",
-  "defaults": Object {},
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": false,
-  "isValid": false,
-  "name": null,
-  "params": "",
-  "value": "",
-}
-`;
-
-exports[`#443 - espree.parse - async (a, b = (i++, true)) => {} 1`] = `
+exports[`#468 - espree.parse - async (a, b = (i++, true)) => {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -18346,6 +10788,7 @@ Object {
     "a": undefined,
     "b": "true",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -18359,7 +10802,7 @@ Object {
 }
 `;
 
-exports[`#444 - espree.parse - async (a = 1) => {} 1`] = `
+exports[`#469 - espree.parse - async (a = 1) => {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -18368,6 +10811,7 @@ Object {
   "defaults": Object {
     "a": "1",
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -18381,7 +10825,7 @@ Object {
 }
 `;
 
-exports[`#445 - espree.parse - async (a) => a * 3 * a 1`] = `
+exports[`#470 - espree.parse - async (a) => a * 3 * a 1`] = `
 Object {
   "args": Array [
     "a",
@@ -18390,6 +10834,7 @@ Object {
   "defaults": Object {
     "a": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -18403,7 +10848,7 @@ Object {
 }
 `;
 
-exports[`#446 - espree.parse - async d => d * 355 * d 1`] = `
+exports[`#471 - espree.parse - async d => d * 355 * d 1`] = `
 Object {
   "args": Array [
     "d",
@@ -18412,6 +10857,7 @@ Object {
   "defaults": Object {
     "d": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -18425,7 +10871,7 @@ Object {
 }
 `;
 
-exports[`#447 - espree.parse - async e => {return e + 5235 / e} 1`] = `
+exports[`#472 - espree.parse - async e => {return e + 5235 / e} 1`] = `
 Object {
   "args": Array [
     "e",
@@ -18434,6 +10880,7 @@ Object {
   "defaults": Object {
     "e": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -18447,115 +10894,7 @@ Object {
 }
 `;
 
-exports[`#447 - espree.parse - should work for object methods 1`] = `
-Object {
-  "args": Array [
-    "a",
-    "b",
-    "c",
-  ],
-  "body": "
-        return 123;
-      ",
-  "defaults": Object {
-    "a": undefined,
-    "b": undefined,
-    "c": undefined,
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "foo",
-  "params": "a, b, c",
-  "value": "({ foo(a, b, c) {
-        return 123;
-      } })",
-}
-`;
-
-exports[`#447 - espree.parse - should work for object methods 2`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "
-        return () => a;
-      ",
-  "defaults": Object {
-    "a": undefined,
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "bar",
-  "params": "a",
-  "value": "({ bar(a) {
-        return () => a;
-      } })",
-}
-`;
-
-exports[`#447 - espree.parse - should work for object methods 3`] = `
-Object {
-  "args": Array [
-    "a",
-  ],
-  "body": "
-        return yield a * 321;
-      ",
-  "defaults": Object {
-    "a": undefined,
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": true,
-  "isNamed": true,
-  "isValid": true,
-  "name": "gen",
-  "params": "a",
-  "value": "({ *gen(a) {
-        return yield a * 321;
-      } })",
-}
-`;
-
-exports[`#447 - espree.parse - should work for object methods 4`] = `
-Object {
-  "args": Array [
-    "a",
-    "cb",
-    "restArgs",
-  ],
-  "body": " return a * 3 ",
-  "defaults": Object {
-    "a": "{foo: 'ba)r', baz: 123}",
-    "cb": undefined,
-    "restArgs": undefined,
-  },
-  "isAnonymous": false,
-  "isArrow": false,
-  "isAsync": false,
-  "isExpression": false,
-  "isGenerator": false,
-  "isNamed": true,
-  "isValid": true,
-  "name": "namedFn",
-  "params": "a, cb, restArgs",
-  "value": "({ namedFn (a = {foo: 'ba)r', baz: 123}, cb, ...restArgs) { return a * 3 } })",
-}
-`;
-
-exports[`#448 - espree.parse - async (a, b) => a + 3 + b 1`] = `
+exports[`#473 - espree.parse - async (a, b) => a + 3 + b 1`] = `
 Object {
   "args": Array [
     "a",
@@ -18566,6 +10905,7 @@ Object {
     "a": undefined,
     "b": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -18579,7 +10919,7 @@ Object {
 }
 `;
 
-exports[`#449 - espree.parse - async (x, y, ...restArgs) => console.log({ value: x * y }) 1`] = `
+exports[`#474 - espree.parse - async (x, y, ...restArgs) => console.log({ value: x * y }) 1`] = `
 Object {
   "args": Array [
     "x",
@@ -18592,6 +10932,7 @@ Object {
     "x": undefined,
     "y": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -18605,14 +10946,19 @@ Object {
 }
 `;
 
-exports[`#450 - espree.parse - async ({x, y}) => {} 1`] = `
+exports[`#475 - espree.parse - async ({x, y}) => {} 1`] = `
 Object {
   "args": Array [
+    false,
+  ],
+  "body": "",
+  "defaults": Object {
+    "false": undefined,
+  },
+  "destructuredArgs": Array [
     "x",
     "y",
   ],
-  "body": "",
-  "defaults": Object {},
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,
@@ -18621,12 +10967,12 @@ Object {
   "isNamed": false,
   "isValid": true,
   "name": null,
-  "params": "x, y",
+  "params": "false",
   "value": "(async ({x, y}) => {})",
 }
 `;
 
-exports[`#451 - espree.parse - should return object with default values when invalid 1`] = `
+exports[`#476 - espree.parse - should return object with default values when invalid 1`] = `
 Object {
   "args": Array [],
   "body": "",
@@ -18644,7 +10990,7 @@ Object {
 }
 `;
 
-exports[`#452 - espree.parse - should have '.isValid' and few '.is*'' hidden properties 1`] = `
+exports[`#477 - espree.parse - should have '.isValid' and few '.is*'' hidden properties 1`] = `
 Object {
   "args": Array [],
   "body": "",
@@ -18662,7 +11008,7 @@ Object {
 }
 `;
 
-exports[`#457 - espree.parse - should work for object methods 1`] = `
+exports[`#482 - espree.parse - should work for object methods 1`] = `
 Object {
   "args": Array [
     "a",
@@ -18677,6 +11023,7 @@ Object {
     "b": undefined,
     "c": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -18692,7 +11039,7 @@ Object {
 }
 `;
 
-exports[`#457 - espree.parse - should work for object methods 2`] = `
+exports[`#482 - espree.parse - should work for object methods 2`] = `
 Object {
   "args": Array [
     "a",
@@ -18703,6 +11050,7 @@ Object {
   "defaults": Object {
     "a": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -18718,7 +11066,7 @@ Object {
 }
 `;
 
-exports[`#457 - espree.parse - should work for object methods 3`] = `
+exports[`#482 - espree.parse - should work for object methods 3`] = `
 Object {
   "args": Array [
     "a",
@@ -18729,6 +11077,7 @@ Object {
   "defaults": Object {
     "a": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -18744,7 +11093,7 @@ Object {
 }
 `;
 
-exports[`#457 - espree.parse - should work for object methods 4`] = `
+exports[`#482 - espree.parse - should work for object methods 4`] = `
 Object {
   "args": Array [
     "a",
@@ -18757,6 +11106,7 @@ Object {
     "cb": undefined,
     "restArgs": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": false,
   "isArrow": false,
   "isAsync": false,
@@ -18779,6 +11129,7 @@ Object {
   "defaults": Object {
     "v": undefined,
   },
+  "destructuredArgs": Array [],
   "isAnonymous": true,
   "isArrow": true,
   "isAsync": true,

--- a/@packages/parse-function/test/__snapshots__/index.js.snap
+++ b/@packages/parse-function/test/__snapshots__/index.js.snap
@@ -1046,7 +1046,80 @@ Object {
 }
 `;
 
+exports[`#46 - babel (default) - x, y}) => {} 1`] = `
+Object {
+  "args": Array [
+    "x",
+    "y",
+  ],
+  "body": "",
+  "defaults": Object {},
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "x, y",
+  "value": "({x, y}) => {}",
+}
+`;
+
+exports[`#47 - babel (default) - async function (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
+Object {
+  "args": Array [
+    "a",
+    "cb",
+    "restArgs",
+  ],
+  "body": "return a * 3",
+  "defaults": Object {
+    "a": "{foo: \\"ba)r\\", baz: 123}",
+    "cb": undefined,
+    "restArgs": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a, cb, restArgs",
+  "value": "async function (a = {foo: \\"ba)r\\", baz: 123}, cb, ...restArgs) {return a * 3}",
+}
+`;
+
 exports[`#47 - babel (default) - async function (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
+Object {
+  "args": Array [
+    "b",
+    "callback",
+    "restArgs",
+  ],
+  "body": "callback(null, b + 3)",
+  "defaults": Object {
+    "b": undefined,
+    "callback": undefined,
+    "restArgs": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "b, callback, restArgs",
+  "value": "async function (b, callback, ...restArgs) {callback(null, b + 3)}",
+}
+`;
+
+exports[`#48 - babel (default) - async function (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
 Object {
   "args": Array [
     "b",
@@ -1116,6 +1189,28 @@ Object {
 }
 `;
 
+exports[`#49 - babel (default) - async function (c) {return c * 3} 1`] = `
+Object {
+  "args": Array [
+    "c",
+  ],
+  "body": "return c * 3",
+  "defaults": Object {
+    "c": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "c",
+  "value": "async function (c) {return c * 3}",
+}
+`;
+
 exports[`#50 - babel (default) - async function () {} 1`] = `
 Object {
   "args": Array [],
@@ -1134,7 +1229,69 @@ Object {
 }
 `;
 
+exports[`#50 - babel (default) - async function (...restArgs) {return 321} 1`] = `
+Object {
+  "args": Array [
+    "restArgs",
+  ],
+  "body": "return 321",
+  "defaults": Object {
+    "restArgs": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "restArgs",
+  "value": "async function (...restArgs) {return 321}",
+}
+`;
+
+exports[`#51 - babel (default) - async function () {} 1`] = `
+Object {
+  "args": Array [],
+  "body": "",
+  "defaults": Object {},
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "",
+  "value": "async function () {}",
+}
+`;
+
 exports[`#51 - babel (default) - async function (a = (true, false)) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "false",
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "async function (a = (true, false)) {}",
+}
+`;
+
+exports[`#52 - babel (default) - async function (a = (true, false)) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -1179,6 +1336,50 @@ Object {
 `;
 
 exports[`#53 - babel (default) - async function (a = (true, "bar")) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "\\"bar\\"",
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "async function (a = (true, \\"bar\\")) {}",
+}
+`;
+
+exports[`#53 - babel (default) - async function (a = (true, null)) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "null",
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "async function (a = (true, null)) {}",
+}
+`;
+
+exports[`#54 - babel (default) - async function (a = (true, "bar")) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -1246,6 +1447,52 @@ Object {
 }
 `;
 
+exports[`#55 - babel (default) - async function (a, b = (i++, true)) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+    "b",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": undefined,
+    "b": "true",
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a, b",
+  "value": "async function (a, b = (i++, true)) {}",
+}
+`;
+
+exports[`#56 - babel (default) - async function (a = 1) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "1",
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "async function (a = 1) {}",
+}
+`;
+
 exports[`#56 - babel (default) - async function namedFn (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
 Object {
   "args": Array [
@@ -1272,7 +1519,59 @@ Object {
 }
 `;
 
+exports[`#57 - babel (default) - async function namedFn (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
+Object {
+  "args": Array [
+    "a",
+    "cb",
+    "restArgs",
+  ],
+  "body": "return a * 3",
+  "defaults": Object {
+    "a": "{foo: \\"ba)r\\", baz: 123}",
+    "cb": undefined,
+    "restArgs": undefined,
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a, cb, restArgs",
+  "value": "async function namedFn (a = {foo: \\"ba)r\\", baz: 123}, cb, ...restArgs) {return a * 3}",
+}
+`;
+
 exports[`#57 - babel (default) - async function namedFn (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
+Object {
+  "args": Array [
+    "b",
+    "callback",
+    "restArgs",
+  ],
+  "body": "callback(null, b + 3)",
+  "defaults": Object {
+    "b": undefined,
+    "callback": undefined,
+    "restArgs": undefined,
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "b, callback, restArgs",
+  "value": "async function namedFn (b, callback, ...restArgs) {callback(null, b + 3)}",
+}
+`;
+
+exports[`#58 - babel (default) - async function namedFn (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
 Object {
   "args": Array [
     "b",
@@ -1342,6 +1641,28 @@ Object {
 }
 `;
 
+exports[`#59 - babel (default) - async function namedFn (c) {return c * 3} 1`] = `
+Object {
+  "args": Array [
+    "c",
+  ],
+  "body": "return c * 3",
+  "defaults": Object {
+    "c": undefined,
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "c",
+  "value": "async function namedFn (c) {return c * 3}",
+}
+`;
+
 exports[`#60 - babel (default) - async function namedFn () {} 1`] = `
 Object {
   "args": Array [],
@@ -1360,7 +1681,69 @@ Object {
 }
 `;
 
+exports[`#60 - babel (default) - async function namedFn (...restArgs) {return 321} 1`] = `
+Object {
+  "args": Array [
+    "restArgs",
+  ],
+  "body": "return 321",
+  "defaults": Object {
+    "restArgs": undefined,
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "restArgs",
+  "value": "async function namedFn (...restArgs) {return 321}",
+}
+`;
+
+exports[`#61 - babel (default) - async function namedFn () {} 1`] = `
+Object {
+  "args": Array [],
+  "body": "",
+  "defaults": Object {},
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "",
+  "value": "async function namedFn () {}",
+}
+`;
+
 exports[`#61 - babel (default) - async function namedFn(a = (true, false)) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "false",
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a",
+  "value": "async function namedFn(a = (true, false)) {}",
+}
+`;
+
+exports[`#62 - babel (default) - async function namedFn(a = (true, false)) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -1405,6 +1788,50 @@ Object {
 `;
 
 exports[`#63 - babel (default) - async function namedFn(a = (true, "bar")) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "\\"bar\\"",
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a",
+  "value": "async function namedFn(a = (true, \\"bar\\")) {}",
+}
+`;
+
+exports[`#63 - babel (default) - async function namedFn(a = (true, null)) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "null",
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a",
+  "value": "async function namedFn(a = (true, null)) {}",
+}
+`;
+
+exports[`#64 - babel (default) - async function namedFn(a = (true, "bar")) {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -1472,6 +1899,30 @@ Object {
 }
 `;
 
+exports[`#65 - babel (default) - async function namedFn(a, b = (i++, true)) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+    "b",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": undefined,
+    "b": "true",
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a, b",
+  "value": "async function namedFn(a, b = (i++, true)) {}",
+}
+`;
+
 exports[`#66 - babel (default) - async (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) => {return a * 3} 1`] = `
 Object {
   "args": Array [
@@ -1498,7 +1949,81 @@ Object {
 }
 `;
 
+exports[`#66 - babel (default) - async function namedFn(a = 1) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "1",
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a",
+  "value": "async function namedFn(a = 1) {}",
+}
+`;
+
+exports[`#67 - babel (default) - async (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) => {return a * 3} 1`] = `
+Object {
+  "args": Array [
+    "a",
+    "cb",
+    "restArgs",
+  ],
+  "body": "return a * 3",
+  "defaults": Object {
+    "a": "{foo: \\"ba)r\\", baz: 123}",
+    "cb": undefined,
+    "restArgs": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a, cb, restArgs",
+  "value": "async (a = {foo: \\"ba)r\\", baz: 123}, cb, ...restArgs) => {return a * 3}",
+}
+`;
+
 exports[`#67 - babel (default) - async (b, callback, ...restArgs) => {callback(null, b + 3)} 1`] = `
+Object {
+  "args": Array [
+    "b",
+    "callback",
+    "restArgs",
+  ],
+  "body": "callback(null, b + 3)",
+  "defaults": Object {
+    "b": undefined,
+    "callback": undefined,
+    "restArgs": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "b, callback, restArgs",
+  "value": "async (b, callback, ...restArgs) => {callback(null, b + 3)}",
+}
+`;
+
+exports[`#68 - babel (default) - async (b, callback, ...restArgs) => {callback(null, b + 3)} 1`] = `
 Object {
   "args": Array [
     "b",
@@ -1568,6 +2093,28 @@ Object {
 }
 `;
 
+exports[`#69 - babel (default) - async (c) => {return c * 3} 1`] = `
+Object {
+  "args": Array [
+    "c",
+  ],
+  "body": "return c * 3",
+  "defaults": Object {
+    "c": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "c",
+  "value": "async (c) => {return c * 3}",
+}
+`;
+
 exports[`#70 - babel (default) - async () => {} 1`] = `
 Object {
   "args": Array [],
@@ -1586,7 +2133,69 @@ Object {
 }
 `;
 
+exports[`#70 - babel (default) - async (...restArgs) => {return 321} 1`] = `
+Object {
+  "args": Array [
+    "restArgs",
+  ],
+  "body": "return 321",
+  "defaults": Object {
+    "restArgs": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "restArgs",
+  "value": "async (...restArgs) => {return 321}",
+}
+`;
+
+exports[`#71 - babel (default) - async () => {} 1`] = `
+Object {
+  "args": Array [],
+  "body": "",
+  "defaults": Object {},
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "",
+  "value": "async () => {}",
+}
+`;
+
 exports[`#71 - babel (default) - async (a = (true, false)) => {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "false",
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "async (a = (true, false)) => {}",
+}
+`;
+
+exports[`#72 - babel (default) - async (a = (true, false)) => {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -1631,6 +2240,50 @@ Object {
 `;
 
 exports[`#73 - babel (default) - async (a = (true, "bar")) => {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "\\"bar\\"",
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "async (a = (true, \\"bar\\")) => {}",
+}
+`;
+
+exports[`#73 - babel (default) - async (a = (true, null)) => {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "null",
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "async (a = (true, null)) => {}",
+}
+`;
+
+exports[`#74 - babel (default) - async (a = (true, "bar")) => {} 1`] = `
 Object {
   "args": Array [
     "a",
@@ -1698,6 +2351,52 @@ Object {
 }
 `;
 
+exports[`#75 - babel (default) - async (a, b = (i++, true)) => {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+    "b",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": undefined,
+    "b": "true",
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a, b",
+  "value": "async (a, b = (i++, true)) => {}",
+}
+`;
+
+exports[`#76 - babel (default) - async (a = 1) => {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "1",
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "async (a = 1) => {}",
+}
+`;
+
 exports[`#76 - babel (default) - async (a) => a * 3 * a 1`] = `
 Object {
   "args": Array [
@@ -1720,7 +2419,51 @@ Object {
 }
 `;
 
+exports[`#77 - babel (default) - async (a) => a * 3 * a 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "a * 3 * a",
+  "defaults": Object {
+    "a": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "async (a) => a * 3 * a",
+}
+`;
+
 exports[`#77 - babel (default) - async d => d * 355 * d 1`] = `
+Object {
+  "args": Array [
+    "d",
+  ],
+  "body": "d * 355 * d",
+  "defaults": Object {
+    "d": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "d",
+  "value": "async d => d * 355 * d",
+}
+`;
+
+exports[`#78 - babel (default) - async d => d * 355 * d 1`] = `
 Object {
   "args": Array [
     "d",
@@ -1788,7 +2531,79 @@ Object {
 }
 `;
 
+exports[`#79 - babel (default) - async e => {return e + 5235 / e} 1`] = `
+Object {
+  "args": Array [
+    "e",
+  ],
+  "body": "return e + 5235 / e",
+  "defaults": Object {
+    "e": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "e",
+  "value": "async e => {return e + 5235 / e}",
+}
+`;
+
+exports[`#80 - babel (default) - async (a, b) => a + 3 + b 1`] = `
+Object {
+  "args": Array [
+    "a",
+    "b",
+  ],
+  "body": "a + 3 + b",
+  "defaults": Object {
+    "a": undefined,
+    "b": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a, b",
+  "value": "async (a, b) => a + 3 + b",
+}
+`;
+
 exports[`#80 - babel (default) - async (x, y, ...restArgs) => console.log({ value: x * y } 1`] = `
+Object {
+  "args": Array [
+    "x",
+    "y",
+    "restArgs",
+  ],
+  "body": "console.log({ value: x * y })",
+  "defaults": Object {
+    "restArgs": undefined,
+    "x": undefined,
+    "y": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "x, y, restArgs",
+  "value": "async (x, y, ...restArgs) => console.log({ value: x * y })",
+}
+`;
+
+exports[`#81 - babel (default) - async (x, y, ...restArgs) => console.log({ value: x * y } 1`] = `
 Object {
   "args": Array [
     "x",
@@ -1832,7 +2647,64 @@ Object {
 }
 `;
 
+exports[`#82 - babel (default) - async ({x, y}) => {} 1`] = `
+Object {
+  "args": Array [
+    "x",
+    "y",
+  ],
+  "body": "",
+  "defaults": Object {},
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "x, y",
+  "value": "async ({x, y}) => {}",
+}
+`;
+
 exports[`#82 - babel (default) - should have '.isValid' and few '.is*'' hidden properties 1`] = `
+Object {
+  "args": Array [],
+  "body": "",
+  "defaults": Object {},
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": false,
+  "name": null,
+  "params": "",
+  "value": "",
+}
+`;
+
+exports[`#83 - babel (default) - should return object with default values when invalid 1`] = `
+Object {
+  "args": Array [],
+  "body": "",
+  "defaults": Object {},
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": false,
+  "name": null,
+  "params": "",
+  "value": "",
+}
+`;
+
+exports[`#84 - babel (default) - should have '.isValid' and few '.is*'' hidden properties 1`] = `
 Object {
   "args": Array [],
   "body": "",
@@ -1958,6 +2830,114 @@ Object {
 }
 `;
 
+exports[`#89 - babel (default) - should work for object methods 1`] = `
+Object {
+  "args": Array [
+    "a",
+    "b",
+    "c",
+  ],
+  "body": "
+        return 123;
+      ",
+  "defaults": Object {
+    "a": undefined,
+    "b": undefined,
+    "c": undefined,
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "foo",
+  "params": "a, b, c",
+  "value": "{ foo(a, b, c) {
+        return 123;
+      } }",
+}
+`;
+
+exports[`#89 - babel (default) - should work for object methods 2`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "
+        return () => a;
+      ",
+  "defaults": Object {
+    "a": undefined,
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "bar",
+  "params": "a",
+  "value": "{ bar(a) {
+        return () => a;
+      } }",
+}
+`;
+
+exports[`#89 - babel (default) - should work for object methods 3`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "
+        return yield a * 321;
+      ",
+  "defaults": Object {
+    "a": undefined,
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": true,
+  "isNamed": true,
+  "isValid": true,
+  "name": "gen",
+  "params": "a",
+  "value": "{ *gen(a) {
+        return yield a * 321;
+      } }",
+}
+`;
+
+exports[`#89 - babel (default) - should work for object methods 4`] = `
+Object {
+  "args": Array [
+    "a",
+    "cb",
+    "restArgs",
+  ],
+  "body": " return a * 3 ",
+  "defaults": Object {
+    "a": "{foo: 'ba)r', baz: 123}",
+    "cb": undefined,
+    "restArgs": undefined,
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a, cb, restArgs",
+  "value": "{ namedFn (a = {foo: 'ba)r', baz: 123}, cb, ...restArgs) { return a * 3 } }",
+}
+`;
+
 exports[`#91 - options.parse + ecmaVersion: 2019 - function (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
 Object {
   "args": Array [
@@ -2010,6 +2990,32 @@ Object {
 }
 `;
 
+exports[`#93 - options.parse + ecmaVersion: 2019 - function (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
+Object {
+  "args": Array [
+    "a",
+    "cb",
+    "restArgs",
+  ],
+  "body": "return a * 3",
+  "defaults": Object {
+    "a": "{foo: \\"ba)r\\", baz: 123}",
+    "cb": undefined,
+    "restArgs": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a, cb, restArgs",
+  "value": "(function (a = {foo: \\"ba)r\\", baz: 123}, cb, ...restArgs) {return a * 3})",
+}
+`;
+
 exports[`#93 - options.parse + ecmaVersion: 2019 - function (c) {return c * 3} 1`] = `
 Object {
   "args": Array [
@@ -2054,6 +3060,32 @@ Object {
 }
 `;
 
+exports[`#94 - options.parse + ecmaVersion: 2019 - function (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
+Object {
+  "args": Array [
+    "b",
+    "callback",
+    "restArgs",
+  ],
+  "body": "callback(null, b + 3)",
+  "defaults": Object {
+    "b": undefined,
+    "callback": undefined,
+    "restArgs": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "b, callback, restArgs",
+  "value": "(function (b, callback, ...restArgs) {callback(null, b + 3)})",
+}
+`;
+
 exports[`#95 - options.parse + ecmaVersion: 2019 - function () {} 1`] = `
 Object {
   "args": Array [],
@@ -2069,6 +3101,50 @@ Object {
   "name": null,
   "params": "",
   "value": "(function () {})",
+}
+`;
+
+exports[`#95 - options.parse + ecmaVersion: 2019 - function (c) {return c * 3} 1`] = `
+Object {
+  "args": Array [
+    "c",
+  ],
+  "body": "return c * 3",
+  "defaults": Object {
+    "c": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "c",
+  "value": "(function (c) {return c * 3})",
+}
+`;
+
+exports[`#96 - options.parse + ecmaVersion: 2019 - function (...restArgs) {return 321} 1`] = `
+Object {
+  "args": Array [
+    "restArgs",
+  ],
+  "body": "return 321",
+  "defaults": Object {
+    "restArgs": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "restArgs",
+  "value": "(function (...restArgs) {return 321})",
 }
 `;
 
@@ -2091,6 +3167,24 @@ Object {
   "name": null,
   "params": "a",
   "value": "(function (a = (true, false)) {})",
+}
+`;
+
+exports[`#97 - options.parse + ecmaVersion: 2019 - function () {} 1`] = `
+Object {
+  "args": Array [],
+  "body": "",
+  "defaults": Object {},
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "",
+  "value": "(function () {})",
 }
 `;
 
@@ -2138,6 +3232,50 @@ Object {
 }
 `;
 
+exports[`#98 - options.parse + ecmaVersion: 2019 - function (a = (true, false)) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "false",
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "(function (a = (true, false)) {})",
+}
+`;
+
+exports[`#99 - options.parse + ecmaVersion: 2019 - function (a = (true, null)) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "null",
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "(function (a = (true, null)) {})",
+}
+`;
+
 exports[`#99 - options.parse + ecmaVersion: 2019 - function (a, b = (i++, true)) {} 1`] = `
 Object {
   "args": Array [
@@ -2162,6 +3300,28 @@ Object {
 }
 `;
 
+exports[`#100 - options.parse + ecmaVersion: 2019 - function (a = (true, "bar")) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "\\"bar\\"",
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "(function (a = (true, \\"bar\\")) {})",
+}
+`;
+
 exports[`#100 - options.parse + ecmaVersion: 2019 - function (a = 1) {} 1`] = `
 Object {
   "args": Array [
@@ -2181,6 +3341,30 @@ Object {
   "name": null,
   "params": "a",
   "value": "(function (a = 1) {})",
+}
+`;
+
+exports[`#101 - options.parse + ecmaVersion: 2019 - function (a, b = (i++, true)) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+    "b",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": undefined,
+    "b": "true",
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a, b",
+  "value": "(function (a, b = (i++, true)) {})",
 }
 `;
 
@@ -2210,6 +3394,28 @@ Object {
 }
 `;
 
+exports[`#102 - options.parse + ecmaVersion: 2019 - function (a = 1) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "1",
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "(function (a = 1) {})",
+}
+`;
+
 exports[`#102 - options.parse + ecmaVersion: 2019 - function namedFn (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
 Object {
   "args": Array [
@@ -2233,6 +3439,32 @@ Object {
   "name": "namedFn",
   "params": "b, callback, restArgs",
   "value": "(function namedFn (b, callback, ...restArgs) {callback(null, b + 3)})",
+}
+`;
+
+exports[`#103 - options.parse + ecmaVersion: 2019 - function namedFn (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
+Object {
+  "args": Array [
+    "a",
+    "cb",
+    "restArgs",
+  ],
+  "body": "return a * 3",
+  "defaults": Object {
+    "a": "{foo: \\"ba)r\\", baz: 123}",
+    "cb": undefined,
+    "restArgs": undefined,
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a, cb, restArgs",
+  "value": "(function namedFn (a = {foo: \\"ba)r\\", baz: 123}, cb, ...restArgs) {return a * 3})",
 }
 `;
 
@@ -2280,6 +3512,32 @@ Object {
 }
 `;
 
+exports[`#104 - options.parse + ecmaVersion: 2019 - function namedFn (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
+Object {
+  "args": Array [
+    "b",
+    "callback",
+    "restArgs",
+  ],
+  "body": "callback(null, b + 3)",
+  "defaults": Object {
+    "b": undefined,
+    "callback": undefined,
+    "restArgs": undefined,
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "b, callback, restArgs",
+  "value": "(function namedFn (b, callback, ...restArgs) {callback(null, b + 3)})",
+}
+`;
+
 exports[`#105 - options.parse + ecmaVersion: 2019 - function namedFn () {} 1`] = `
 Object {
   "args": Array [],
@@ -2295,6 +3553,50 @@ Object {
   "name": "namedFn",
   "params": "",
   "value": "(function namedFn () {})",
+}
+`;
+
+exports[`#105 - options.parse + ecmaVersion: 2019 - function namedFn (c) {return c * 3} 1`] = `
+Object {
+  "args": Array [
+    "c",
+  ],
+  "body": "return c * 3",
+  "defaults": Object {
+    "c": undefined,
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "c",
+  "value": "(function namedFn (c) {return c * 3})",
+}
+`;
+
+exports[`#106 - options.parse + ecmaVersion: 2019 - function namedFn (...restArgs) {return 321} 1`] = `
+Object {
+  "args": Array [
+    "restArgs",
+  ],
+  "body": "return 321",
+  "defaults": Object {
+    "restArgs": undefined,
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "restArgs",
+  "value": "(function namedFn (...restArgs) {return 321})",
 }
 `;
 
@@ -2317,6 +3619,24 @@ Object {
   "name": "namedFn",
   "params": "a",
   "value": "(function namedFn(a = (true, false)) {})",
+}
+`;
+
+exports[`#107 - options.parse + ecmaVersion: 2019 - function namedFn () {} 1`] = `
+Object {
+  "args": Array [],
+  "body": "",
+  "defaults": Object {},
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "",
+  "value": "(function namedFn () {})",
 }
 `;
 
@@ -2364,6 +3684,50 @@ Object {
 }
 `;
 
+exports[`#108 - options.parse + ecmaVersion: 2019 - function namedFn(a = (true, false)) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "false",
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a",
+  "value": "(function namedFn(a = (true, false)) {})",
+}
+`;
+
+exports[`#109 - options.parse + ecmaVersion: 2019 - function namedFn(a = (true, null)) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "null",
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a",
+  "value": "(function namedFn(a = (true, null)) {})",
+}
+`;
+
 exports[`#109 - options.parse + ecmaVersion: 2019 - function namedFn(a, b = (i++, true)) {} 1`] = `
 Object {
   "args": Array [
@@ -2385,6 +3749,28 @@ Object {
   "name": "namedFn",
   "params": "a, b",
   "value": "(function namedFn(a, b = (i++, true)) {})",
+}
+`;
+
+exports[`#110 - options.parse + ecmaVersion: 2019 - function namedFn(a = (true, "bar")) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "\\"bar\\"",
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a",
+  "value": "(function namedFn(a = (true, \\"bar\\")) {})",
 }
 `;
 
@@ -2436,6 +3822,30 @@ Object {
 }
 `;
 
+exports[`#111 - options.parse + ecmaVersion: 2019 - function namedFn(a, b = (i++, true)) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+    "b",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": undefined,
+    "b": "true",
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a, b",
+  "value": "(function namedFn(a, b = (i++, true)) {})",
+}
+`;
+
 exports[`#112 - options.parse + ecmaVersion: 2019 - function * namedFn (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
 Object {
   "args": Array [
@@ -2459,6 +3869,54 @@ Object {
   "name": "namedFn",
   "params": "b, callback, restArgs",
   "value": "(function * namedFn (b, callback, ...restArgs) {callback(null, b + 3)})",
+}
+`;
+
+exports[`#112 - options.parse + ecmaVersion: 2019 - function namedFn(a = 1) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "1",
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a",
+  "value": "(function namedFn(a = 1) {})",
+}
+`;
+
+exports[`#113 - options.parse + ecmaVersion: 2019 - function * namedFn (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
+Object {
+  "args": Array [
+    "a",
+    "cb",
+    "restArgs",
+  ],
+  "body": "return a * 3",
+  "defaults": Object {
+    "a": "{foo: \\"ba)r\\", baz: 123}",
+    "cb": undefined,
+    "restArgs": undefined,
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": true,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a, cb, restArgs",
+  "value": "(function * namedFn (a = {foo: \\"ba)r\\", baz: 123}, cb, ...restArgs) {return a * 3})",
 }
 `;
 
@@ -2506,6 +3964,32 @@ Object {
 }
 `;
 
+exports[`#114 - options.parse + ecmaVersion: 2019 - function * namedFn (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
+Object {
+  "args": Array [
+    "b",
+    "callback",
+    "restArgs",
+  ],
+  "body": "callback(null, b + 3)",
+  "defaults": Object {
+    "b": undefined,
+    "callback": undefined,
+    "restArgs": undefined,
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": true,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "b, callback, restArgs",
+  "value": "(function * namedFn (b, callback, ...restArgs) {callback(null, b + 3)})",
+}
+`;
+
 exports[`#115 - options.parse + ecmaVersion: 2019 - function * namedFn () {} 1`] = `
 Object {
   "args": Array [],
@@ -2521,6 +4005,50 @@ Object {
   "name": "namedFn",
   "params": "",
   "value": "(function * namedFn () {})",
+}
+`;
+
+exports[`#115 - options.parse + ecmaVersion: 2019 - function * namedFn (c) {return c * 3} 1`] = `
+Object {
+  "args": Array [
+    "c",
+  ],
+  "body": "return c * 3",
+  "defaults": Object {
+    "c": undefined,
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": true,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "c",
+  "value": "(function * namedFn (c) {return c * 3})",
+}
+`;
+
+exports[`#116 - options.parse + ecmaVersion: 2019 - function * namedFn (...restArgs) {return 321} 1`] = `
+Object {
+  "args": Array [
+    "restArgs",
+  ],
+  "body": "return 321",
+  "defaults": Object {
+    "restArgs": undefined,
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": true,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "restArgs",
+  "value": "(function * namedFn (...restArgs) {return 321})",
 }
 `;
 
@@ -2543,6 +4071,24 @@ Object {
   "name": "namedFn",
   "params": "a",
   "value": "(function * namedFn(a = (true, false)) {})",
+}
+`;
+
+exports[`#117 - options.parse + ecmaVersion: 2019 - function * namedFn () {} 1`] = `
+Object {
+  "args": Array [],
+  "body": "",
+  "defaults": Object {},
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": true,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "",
+  "value": "(function * namedFn () {})",
 }
 `;
 
@@ -2590,6 +4136,50 @@ Object {
 }
 `;
 
+exports[`#118 - options.parse + ecmaVersion: 2019 - function * namedFn(a = (true, false)) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "false",
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": true,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a",
+  "value": "(function * namedFn(a = (true, false)) {})",
+}
+`;
+
+exports[`#119 - options.parse + ecmaVersion: 2019 - function * namedFn(a = (true, null)) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "null",
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": true,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a",
+  "value": "(function * namedFn(a = (true, null)) {})",
+}
+`;
+
 exports[`#119 - options.parse + ecmaVersion: 2019 - function * namedFn(a, b = (i++, true)) {} 1`] = `
 Object {
   "args": Array [
@@ -2611,6 +4201,28 @@ Object {
   "name": "namedFn",
   "params": "a, b",
   "value": "(function * namedFn(a, b = (i++, true)) {})",
+}
+`;
+
+exports[`#120 - options.parse + ecmaVersion: 2019 - function * namedFn(a = (true, "bar")) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "\\"bar\\"",
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": true,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a",
+  "value": "(function * namedFn(a = (true, \\"bar\\")) {})",
 }
 `;
 
@@ -2662,6 +4274,30 @@ Object {
 }
 `;
 
+exports[`#121 - options.parse + ecmaVersion: 2019 - function * namedFn(a, b = (i++, true)) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+    "b",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": undefined,
+    "b": "true",
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": true,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a, b",
+  "value": "(function * namedFn(a, b = (i++, true)) {})",
+}
+`;
+
 exports[`#122 - options.parse + ecmaVersion: 2019 - (b, callback, ...restArgs) => {callback(null, b + 3)} 1`] = `
 Object {
   "args": Array [
@@ -2685,6 +4321,54 @@ Object {
   "name": null,
   "params": "b, callback, restArgs",
   "value": "((b, callback, ...restArgs) => {callback(null, b + 3)})",
+}
+`;
+
+exports[`#122 - options.parse + ecmaVersion: 2019 - function * namedFn(a = 1) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "1",
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": true,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a",
+  "value": "(function * namedFn(a = 1) {})",
+}
+`;
+
+exports[`#123 - options.parse + ecmaVersion: 2019 - (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) => {return a * 3} 1`] = `
+Object {
+  "args": Array [
+    "a",
+    "cb",
+    "restArgs",
+  ],
+  "body": "return a * 3",
+  "defaults": Object {
+    "a": "{foo: \\"ba)r\\", baz: 123}",
+    "cb": undefined,
+    "restArgs": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a, cb, restArgs",
+  "value": "((a = {foo: \\"ba)r\\", baz: 123}, cb, ...restArgs) => {return a * 3})",
 }
 `;
 
@@ -2732,6 +4416,32 @@ Object {
 }
 `;
 
+exports[`#124 - options.parse + ecmaVersion: 2019 - (b, callback, ...restArgs) => {callback(null, b + 3)} 1`] = `
+Object {
+  "args": Array [
+    "b",
+    "callback",
+    "restArgs",
+  ],
+  "body": "callback(null, b + 3)",
+  "defaults": Object {
+    "b": undefined,
+    "callback": undefined,
+    "restArgs": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "b, callback, restArgs",
+  "value": "((b, callback, ...restArgs) => {callback(null, b + 3)})",
+}
+`;
+
 exports[`#125 - options.parse + ecmaVersion: 2019 - () => {} 1`] = `
 Object {
   "args": Array [],
@@ -2747,6 +4457,50 @@ Object {
   "name": null,
   "params": "",
   "value": "(() => {})",
+}
+`;
+
+exports[`#125 - options.parse + ecmaVersion: 2019 - (c) => {return c * 3} 1`] = `
+Object {
+  "args": Array [
+    "c",
+  ],
+  "body": "return c * 3",
+  "defaults": Object {
+    "c": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "c",
+  "value": "((c) => {return c * 3})",
+}
+`;
+
+exports[`#126 - options.parse + ecmaVersion: 2019 - (...restArgs) => {return 321} 1`] = `
+Object {
+  "args": Array [
+    "restArgs",
+  ],
+  "body": "return 321",
+  "defaults": Object {
+    "restArgs": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "restArgs",
+  "value": "((...restArgs) => {return 321})",
 }
 `;
 
@@ -2769,6 +4523,24 @@ Object {
   "name": null,
   "params": "a",
   "value": "((a = (true, false)) => {})",
+}
+`;
+
+exports[`#127 - options.parse + ecmaVersion: 2019 - () => {} 1`] = `
+Object {
+  "args": Array [],
+  "body": "",
+  "defaults": Object {},
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "",
+  "value": "(() => {})",
 }
 `;
 
@@ -2816,6 +4588,50 @@ Object {
 }
 `;
 
+exports[`#128 - options.parse + ecmaVersion: 2019 - (a = (true, false)) => {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "false",
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "((a = (true, false)) => {})",
+}
+`;
+
+exports[`#129 - options.parse + ecmaVersion: 2019 - (a = (true, null)) => {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "null",
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "((a = (true, null)) => {})",
+}
+`;
+
 exports[`#129 - options.parse + ecmaVersion: 2019 - (a, b = (i++, true)) => {} 1`] = `
 Object {
   "args": Array [
@@ -2837,6 +4653,28 @@ Object {
   "name": null,
   "params": "a, b",
   "value": "((a, b = (i++, true)) => {})",
+}
+`;
+
+exports[`#130 - options.parse + ecmaVersion: 2019 - (a = (true, "bar")) => {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "\\"bar\\"",
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "((a = (true, \\"bar\\")) => {})",
 }
 `;
 
@@ -2884,6 +4722,52 @@ Object {
 }
 `;
 
+exports[`#131 - options.parse + ecmaVersion: 2019 - (a, b = (i++, true)) => {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+    "b",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": undefined,
+    "b": "true",
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a, b",
+  "value": "((a, b = (i++, true)) => {})",
+}
+`;
+
+exports[`#132 - options.parse + ecmaVersion: 2019 - (a = 1) => {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "1",
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "((a = 1) => {})",
+}
+`;
+
 exports[`#132 - options.parse + ecmaVersion: 2019 - d => d * 355 * d 1`] = `
 Object {
   "args": Array [
@@ -2903,6 +4787,28 @@ Object {
   "name": null,
   "params": "d",
   "value": "(d => d * 355 * d)",
+}
+`;
+
+exports[`#133 - options.parse + ecmaVersion: 2019 - (a) => a * 3 * a 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "a * 3 * a",
+  "defaults": Object {
+    "a": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "((a) => a * 3 * a)",
 }
 `;
 
@@ -2952,6 +4858,28 @@ Object {
 }
 `;
 
+exports[`#134 - options.parse + ecmaVersion: 2019 - d => d * 355 * d 1`] = `
+Object {
+  "args": Array [
+    "d",
+  ],
+  "body": "d * 355 * d",
+  "defaults": Object {
+    "d": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "d",
+  "value": "(d => d * 355 * d)",
+}
+`;
+
 exports[`#135 - options.parse + ecmaVersion: 2019 - (x, y, ...restArgs) => console.log({ value: x * y }) 1`] = `
 Object {
   "args": Array [
@@ -2975,6 +4903,52 @@ Object {
   "name": null,
   "params": "x, y, restArgs",
   "value": "((x, y, ...restArgs) => console.log({ value: x * y }))",
+}
+`;
+
+exports[`#135 - options.parse + ecmaVersion: 2019 - e => {return e + 5235 / e} 1`] = `
+Object {
+  "args": Array [
+    "e",
+  ],
+  "body": "return e + 5235 / e",
+  "defaults": Object {
+    "e": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "e",
+  "value": "(e => {return e + 5235 / e})",
+}
+`;
+
+exports[`#136 - options.parse + ecmaVersion: 2019 - (a, b) => a + 3 + b 1`] = `
+Object {
+  "args": Array [
+    "a",
+    "b",
+  ],
+  "body": "a + 3 + b",
+  "defaults": Object {
+    "a": undefined,
+    "b": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a, b",
+  "value": "((a, b) => a + 3 + b)",
 }
 `;
 
@@ -3004,6 +4978,32 @@ Object {
 }
 `;
 
+exports[`#137 - options.parse + ecmaVersion: 2019 - (x, y, ...restArgs) => console.log({ value: x * y }) 1`] = `
+Object {
+  "args": Array [
+    "x",
+    "y",
+    "restArgs",
+  ],
+  "body": "console.log({ value: x * y })",
+  "defaults": Object {
+    "restArgs": undefined,
+    "x": undefined,
+    "y": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "x, y, restArgs",
+  "value": "((x, y, ...restArgs) => console.log({ value: x * y }))",
+}
+`;
+
 exports[`#137 - options.parse + ecmaVersion: 2019 - async function (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
 Object {
   "args": Array [
@@ -3027,6 +5027,27 @@ Object {
   "name": null,
   "params": "b, callback, restArgs",
   "value": "(async function (b, callback, ...restArgs) {callback(null, b + 3)})",
+}
+`;
+
+exports[`#138 - options.parse + ecmaVersion: 2019 - ({x, y}) => {} 1`] = `
+Object {
+  "args": Array [
+    "x",
+    "y",
+  ],
+  "body": "",
+  "defaults": Object {},
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "x, y",
+  "value": "(({x, y}) => {})",
 }
 `;
 
@@ -3074,6 +5095,32 @@ Object {
 }
 `;
 
+exports[`#139 - options.parse + ecmaVersion: 2019 - async function (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
+Object {
+  "args": Array [
+    "a",
+    "cb",
+    "restArgs",
+  ],
+  "body": "return a * 3",
+  "defaults": Object {
+    "a": "{foo: \\"ba)r\\", baz: 123}",
+    "cb": undefined,
+    "restArgs": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a, cb, restArgs",
+  "value": "(async function (a = {foo: \\"ba)r\\", baz: 123}, cb, ...restArgs) {return a * 3})",
+}
+`;
+
 exports[`#140 - options.parse + ecmaVersion: 2019 - async function () {} 1`] = `
 Object {
   "args": Array [],
@@ -3089,6 +5136,32 @@ Object {
   "name": null,
   "params": "",
   "value": "(async function () {})",
+}
+`;
+
+exports[`#140 - options.parse + ecmaVersion: 2019 - async function (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
+Object {
+  "args": Array [
+    "b",
+    "callback",
+    "restArgs",
+  ],
+  "body": "callback(null, b + 3)",
+  "defaults": Object {
+    "b": undefined,
+    "callback": undefined,
+    "restArgs": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "b, callback, restArgs",
+  "value": "(async function (b, callback, ...restArgs) {callback(null, b + 3)})",
 }
 `;
 
@@ -3114,6 +5187,50 @@ Object {
 }
 `;
 
+exports[`#141 - options.parse + ecmaVersion: 2019 - async function (c) {return c * 3} 1`] = `
+Object {
+  "args": Array [
+    "c",
+  ],
+  "body": "return c * 3",
+  "defaults": Object {
+    "c": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "c",
+  "value": "(async function (c) {return c * 3})",
+}
+`;
+
+exports[`#142 - options.parse + ecmaVersion: 2019 - async function (...restArgs) {return 321} 1`] = `
+Object {
+  "args": Array [
+    "restArgs",
+  ],
+  "body": "return 321",
+  "defaults": Object {
+    "restArgs": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "restArgs",
+  "value": "(async function (...restArgs) {return 321})",
+}
+`;
+
 exports[`#142 - options.parse + ecmaVersion: 2019 - async function (a = (true, null)) {} 1`] = `
 Object {
   "args": Array [
@@ -3136,6 +5253,24 @@ Object {
 }
 `;
 
+exports[`#143 - options.parse + ecmaVersion: 2019 - async function () {} 1`] = `
+Object {
+  "args": Array [],
+  "body": "",
+  "defaults": Object {},
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "",
+  "value": "(async function () {})",
+}
+`;
+
 exports[`#143 - options.parse + ecmaVersion: 2019 - async function (a = (true, "bar")) {} 1`] = `
 Object {
   "args": Array [
@@ -3155,6 +5290,28 @@ Object {
   "name": null,
   "params": "a",
   "value": "(async function (a = (true, \\"bar\\")) {})",
+}
+`;
+
+exports[`#144 - options.parse + ecmaVersion: 2019 - async function (a = (true, false)) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "false",
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "(async function (a = (true, false)) {})",
 }
 `;
 
@@ -3182,6 +5339,28 @@ Object {
 }
 `;
 
+exports[`#145 - options.parse + ecmaVersion: 2019 - async function (a = (true, null)) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "null",
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "(async function (a = (true, null)) {})",
+}
+`;
+
 exports[`#145 - options.parse + ecmaVersion: 2019 - async function (a = 1) {} 1`] = `
 Object {
   "args": Array [
@@ -3201,6 +5380,28 @@ Object {
   "name": null,
   "params": "a",
   "value": "(async function (a = 1) {})",
+}
+`;
+
+exports[`#146 - options.parse + ecmaVersion: 2019 - async function (a = (true, "bar")) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "\\"bar\\"",
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "(async function (a = (true, \\"bar\\")) {})",
 }
 `;
 
@@ -3230,6 +5431,30 @@ Object {
 }
 `;
 
+exports[`#147 - options.parse + ecmaVersion: 2019 - async function (a, b = (i++, true)) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+    "b",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": undefined,
+    "b": "true",
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a, b",
+  "value": "(async function (a, b = (i++, true)) {})",
+}
+`;
+
 exports[`#147 - options.parse + ecmaVersion: 2019 - async function namedFn (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
 Object {
   "args": Array [
@@ -3253,6 +5478,28 @@ Object {
   "name": "namedFn",
   "params": "b, callback, restArgs",
   "value": "(async function namedFn (b, callback, ...restArgs) {callback(null, b + 3)})",
+}
+`;
+
+exports[`#148 - options.parse + ecmaVersion: 2019 - async function (a = 1) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "1",
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "(async function (a = 1) {})",
 }
 `;
 
@@ -3300,6 +5547,32 @@ Object {
 }
 `;
 
+exports[`#149 - options.parse + ecmaVersion: 2019 - async function namedFn (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
+Object {
+  "args": Array [
+    "a",
+    "cb",
+    "restArgs",
+  ],
+  "body": "return a * 3",
+  "defaults": Object {
+    "a": "{foo: \\"ba)r\\", baz: 123}",
+    "cb": undefined,
+    "restArgs": undefined,
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a, cb, restArgs",
+  "value": "(async function namedFn (a = {foo: \\"ba)r\\", baz: 123}, cb, ...restArgs) {return a * 3})",
+}
+`;
+
 exports[`#150 - options.parse + ecmaVersion: 2019 - async function namedFn () {} 1`] = `
 Object {
   "args": Array [],
@@ -3315,6 +5588,54 @@ Object {
   "name": "namedFn",
   "params": "",
   "value": "(async function namedFn () {})",
+}
+`;
+
+exports[`#150 - options.parse + ecmaVersion: 2019 - async function namedFn (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
+Object {
+  "args": Array [
+    "b",
+    "callback",
+    "restArgs",
+  ],
+  "body": "callback(null, b + 3)",
+  "defaults": Object {
+    "b": undefined,
+    "callback": undefined,
+    "restArgs": undefined,
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "b, callback, restArgs",
+  "value": "(async function namedFn (b, callback, ...restArgs) {callback(null, b + 3)})",
+}
+`;
+
+exports[`#151 - options.parse + ecmaVersion: 2019 - async function namedFn (c) {return c * 3} 1`] = `
+Object {
+  "args": Array [
+    "c",
+  ],
+  "body": "return c * 3",
+  "defaults": Object {
+    "c": undefined,
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "c",
+  "value": "(async function namedFn (c) {return c * 3})",
 }
 `;
 
@@ -3340,6 +5661,28 @@ Object {
 }
 `;
 
+exports[`#152 - options.parse + ecmaVersion: 2019 - async function namedFn (...restArgs) {return 321} 1`] = `
+Object {
+  "args": Array [
+    "restArgs",
+  ],
+  "body": "return 321",
+  "defaults": Object {
+    "restArgs": undefined,
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "restArgs",
+  "value": "(async function namedFn (...restArgs) {return 321})",
+}
+`;
+
 exports[`#152 - options.parse + ecmaVersion: 2019 - async function namedFn(a = (true, null)) {} 1`] = `
 Object {
   "args": Array [
@@ -3359,6 +5702,24 @@ Object {
   "name": "namedFn",
   "params": "a",
   "value": "(async function namedFn(a = (true, null)) {})",
+}
+`;
+
+exports[`#153 - options.parse + ecmaVersion: 2019 - async function namedFn () {} 1`] = `
+Object {
+  "args": Array [],
+  "body": "",
+  "defaults": Object {},
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "",
+  "value": "(async function namedFn () {})",
 }
 `;
 
@@ -3384,6 +5745,28 @@ Object {
 }
 `;
 
+exports[`#154 - options.parse + ecmaVersion: 2019 - async function namedFn(a = (true, false)) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "false",
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a",
+  "value": "(async function namedFn(a = (true, false)) {})",
+}
+`;
+
 exports[`#154 - options.parse + ecmaVersion: 2019 - async function namedFn(a, b = (i++, true)) {} 1`] = `
 Object {
   "args": Array [
@@ -3405,6 +5788,28 @@ Object {
   "name": "namedFn",
   "params": "a, b",
   "value": "(async function namedFn(a, b = (i++, true)) {})",
+}
+`;
+
+exports[`#155 - options.parse + ecmaVersion: 2019 - async function namedFn(a = (true, null)) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "null",
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a",
+  "value": "(async function namedFn(a = (true, null)) {})",
 }
 `;
 
@@ -3456,6 +5861,28 @@ Object {
 }
 `;
 
+exports[`#156 - options.parse + ecmaVersion: 2019 - async function namedFn(a = (true, "bar")) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "\\"bar\\"",
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a",
+  "value": "(async function namedFn(a = (true, \\"bar\\")) {})",
+}
+`;
+
 exports[`#157 - options.parse + ecmaVersion: 2019 - async (b, callback, ...restArgs) => {callback(null, b + 3)} 1`] = `
 Object {
   "args": Array [
@@ -3482,6 +5909,30 @@ Object {
 }
 `;
 
+exports[`#157 - options.parse + ecmaVersion: 2019 - async function namedFn(a, b = (i++, true)) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+    "b",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": undefined,
+    "b": "true",
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a, b",
+  "value": "(async function namedFn(a, b = (i++, true)) {})",
+}
+`;
+
 exports[`#158 - options.parse + ecmaVersion: 2019 - async (c) => {return c * 3} 1`] = `
 Object {
   "args": Array [
@@ -3501,6 +5952,28 @@ Object {
   "name": null,
   "params": "c",
   "value": "(async (c) => {return c * 3})",
+}
+`;
+
+exports[`#158 - options.parse + ecmaVersion: 2019 - async function namedFn(a = 1) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "1",
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a",
+  "value": "(async function namedFn(a = 1) {})",
 }
 `;
 
@@ -3526,6 +5999,32 @@ Object {
 }
 `;
 
+exports[`#159 - options.parse + ecmaVersion: 2019 - async (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) => {return a * 3} 1`] = `
+Object {
+  "args": Array [
+    "a",
+    "cb",
+    "restArgs",
+  ],
+  "body": "return a * 3",
+  "defaults": Object {
+    "a": "{foo: \\"ba)r\\", baz: 123}",
+    "cb": undefined,
+    "restArgs": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a, cb, restArgs",
+  "value": "(async (a = {foo: \\"ba)r\\", baz: 123}, cb, ...restArgs) => {return a * 3})",
+}
+`;
+
 exports[`#160 - options.parse + ecmaVersion: 2019 - async () => {} 1`] = `
 Object {
   "args": Array [],
@@ -3541,6 +6040,32 @@ Object {
   "name": null,
   "params": "",
   "value": "(async () => {})",
+}
+`;
+
+exports[`#160 - options.parse + ecmaVersion: 2019 - async (b, callback, ...restArgs) => {callback(null, b + 3)} 1`] = `
+Object {
+  "args": Array [
+    "b",
+    "callback",
+    "restArgs",
+  ],
+  "body": "callback(null, b + 3)",
+  "defaults": Object {
+    "b": undefined,
+    "callback": undefined,
+    "restArgs": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "b, callback, restArgs",
+  "value": "(async (b, callback, ...restArgs) => {callback(null, b + 3)})",
 }
 `;
 
@@ -3566,6 +6091,50 @@ Object {
 }
 `;
 
+exports[`#161 - options.parse + ecmaVersion: 2019 - async (c) => {return c * 3} 1`] = `
+Object {
+  "args": Array [
+    "c",
+  ],
+  "body": "return c * 3",
+  "defaults": Object {
+    "c": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "c",
+  "value": "(async (c) => {return c * 3})",
+}
+`;
+
+exports[`#162 - options.parse + ecmaVersion: 2019 - async (...restArgs) => {return 321} 1`] = `
+Object {
+  "args": Array [
+    "restArgs",
+  ],
+  "body": "return 321",
+  "defaults": Object {
+    "restArgs": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "restArgs",
+  "value": "(async (...restArgs) => {return 321})",
+}
+`;
+
 exports[`#162 - options.parse + ecmaVersion: 2019 - async (a = (true, null)) => {} 1`] = `
 Object {
   "args": Array [
@@ -3588,6 +6157,24 @@ Object {
 }
 `;
 
+exports[`#163 - options.parse + ecmaVersion: 2019 - async () => {} 1`] = `
+Object {
+  "args": Array [],
+  "body": "",
+  "defaults": Object {},
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "",
+  "value": "(async () => {})",
+}
+`;
+
 exports[`#163 - options.parse + ecmaVersion: 2019 - async (a = (true, "bar")) => {} 1`] = `
 Object {
   "args": Array [
@@ -3607,6 +6194,28 @@ Object {
   "name": null,
   "params": "a",
   "value": "(async (a = (true, \\"bar\\")) => {})",
+}
+`;
+
+exports[`#164 - options.parse + ecmaVersion: 2019 - async (a = (true, false)) => {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "false",
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "(async (a = (true, false)) => {})",
 }
 `;
 
@@ -3634,6 +6243,28 @@ Object {
 }
 `;
 
+exports[`#165 - options.parse + ecmaVersion: 2019 - async (a = (true, null)) => {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "null",
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "(async (a = (true, null)) => {})",
+}
+`;
+
 exports[`#165 - options.parse + ecmaVersion: 2019 - async (a = 1) => {} 1`] = `
 Object {
   "args": Array [
@@ -3653,6 +6284,28 @@ Object {
   "name": null,
   "params": "a",
   "value": "(async (a = 1) => {})",
+}
+`;
+
+exports[`#166 - options.parse + ecmaVersion: 2019 - async (a = (true, "bar")) => {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "\\"bar\\"",
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "(async (a = (true, \\"bar\\")) => {})",
 }
 `;
 
@@ -3678,6 +6331,30 @@ Object {
 }
 `;
 
+exports[`#167 - options.parse + ecmaVersion: 2019 - async (a, b = (i++, true)) => {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+    "b",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": undefined,
+    "b": "true",
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a, b",
+  "value": "(async (a, b = (i++, true)) => {})",
+}
+`;
+
 exports[`#167 - options.parse + ecmaVersion: 2019 - async d => d * 355 * d 1`] = `
 Object {
   "args": Array [
@@ -3700,6 +6377,28 @@ Object {
 }
 `;
 
+exports[`#168 - options.parse + ecmaVersion: 2019 - async (a = 1) => {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "1",
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "(async (a = 1) => {})",
+}
+`;
+
 exports[`#168 - options.parse + ecmaVersion: 2019 - async e => {return e + 5235 / e} 1`] = `
 Object {
   "args": Array [
@@ -3719,6 +6418,28 @@ Object {
   "name": null,
   "params": "e",
   "value": "(async e => {return e + 5235 / e})",
+}
+`;
+
+exports[`#169 - options.parse + ecmaVersion: 2019 - async (a) => a * 3 * a 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "a * 3 * a",
+  "defaults": Object {
+    "a": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "(async (a) => a * 3 * a)",
 }
 `;
 
@@ -3772,6 +6493,50 @@ Object {
 }
 `;
 
+exports[`#170 - options.parse + ecmaVersion: 2019 - async d => d * 355 * d 1`] = `
+Object {
+  "args": Array [
+    "d",
+  ],
+  "body": "d * 355 * d",
+  "defaults": Object {
+    "d": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "d",
+  "value": "(async d => d * 355 * d)",
+}
+`;
+
+exports[`#171 - options.parse + ecmaVersion: 2019 - async e => {return e + 5235 / e} 1`] = `
+Object {
+  "args": Array [
+    "e",
+  ],
+  "body": "return e + 5235 / e",
+  "defaults": Object {
+    "e": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "e",
+  "value": "(async e => {return e + 5235 / e})",
+}
+`;
+
 exports[`#171 - options.parse + ecmaVersion: 2019 - should return object with default values when invalid 1`] = `
 Object {
   "args": Array [],
@@ -3790,7 +6555,114 @@ Object {
 }
 `;
 
+exports[`#172 - options.parse + ecmaVersion: 2019 - async (a, b) => a + 3 + b 1`] = `
+Object {
+  "args": Array [
+    "a",
+    "b",
+  ],
+  "body": "a + 3 + b",
+  "defaults": Object {
+    "a": undefined,
+    "b": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a, b",
+  "value": "(async (a, b) => a + 3 + b)",
+}
+`;
+
 exports[`#172 - options.parse + ecmaVersion: 2019 - should have '.isValid' and few '.is*'' hidden properties 1`] = `
+Object {
+  "args": Array [],
+  "body": "",
+  "defaults": Object {},
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": false,
+  "name": null,
+  "params": "",
+  "value": "",
+}
+`;
+
+exports[`#173 - options.parse + ecmaVersion: 2019 - async (x, y, ...restArgs) => console.log({ value: x * y }) 1`] = `
+Object {
+  "args": Array [
+    "x",
+    "y",
+    "restArgs",
+  ],
+  "body": "console.log({ value: x * y })",
+  "defaults": Object {
+    "restArgs": undefined,
+    "x": undefined,
+    "y": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "x, y, restArgs",
+  "value": "(async (x, y, ...restArgs) => console.log({ value: x * y }))",
+}
+`;
+
+exports[`#174 - options.parse + ecmaVersion: 2019 - async ({x, y}) => {} 1`] = `
+Object {
+  "args": Array [
+    "x",
+    "y",
+  ],
+  "body": "",
+  "defaults": Object {},
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "x, y",
+  "value": "(async ({x, y}) => {})",
+}
+`;
+
+exports[`#175 - options.parse + ecmaVersion: 2019 - should return object with default values when invalid 1`] = `
+Object {
+  "args": Array [],
+  "body": "",
+  "defaults": Object {},
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": false,
+  "name": null,
+  "params": "",
+  "value": "",
+}
+`;
+
+exports[`#176 - options.parse + ecmaVersion: 2019 - should have '.isValid' and few '.is*'' hidden properties 1`] = `
 Object {
   "args": Array [],
   "body": "",
@@ -3942,6 +6814,114 @@ Object {
 }
 `;
 
+exports[`#181 - options.parse + ecmaVersion: 2019 - should work for object methods 1`] = `
+Object {
+  "args": Array [
+    "a",
+    "b",
+    "c",
+  ],
+  "body": "
+        return 123;
+      ",
+  "defaults": Object {
+    "a": undefined,
+    "b": undefined,
+    "c": undefined,
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "foo",
+  "params": "a, b, c",
+  "value": "({ foo(a, b, c) {
+        return 123;
+      } })",
+}
+`;
+
+exports[`#181 - options.parse + ecmaVersion: 2019 - should work for object methods 2`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "
+        return () => a;
+      ",
+  "defaults": Object {
+    "a": undefined,
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "bar",
+  "params": "a",
+  "value": "({ bar(a) {
+        return () => a;
+      } })",
+}
+`;
+
+exports[`#181 - options.parse + ecmaVersion: 2019 - should work for object methods 3`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "
+        return yield a * 321;
+      ",
+  "defaults": Object {
+    "a": undefined,
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": true,
+  "isNamed": true,
+  "isValid": true,
+  "name": "gen",
+  "params": "a",
+  "value": "({ *gen(a) {
+        return yield a * 321;
+      } })",
+}
+`;
+
+exports[`#181 - options.parse + ecmaVersion: 2019 - should work for object methods 4`] = `
+Object {
+  "args": Array [
+    "a",
+    "cb",
+    "restArgs",
+  ],
+  "body": " return a * 3 ",
+  "defaults": Object {
+    "a": "{foo: 'ba)r', baz: 123}",
+    "cb": undefined,
+    "restArgs": undefined,
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a, cb, restArgs",
+  "value": "({ namedFn (a = {foo: 'ba)r', baz: 123}, cb, ...restArgs) { return a * 3 } })",
+}
+`;
+
 exports[`#182 - acorn.parse - function (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
 Object {
   "args": Array [
@@ -4030,6 +7010,32 @@ Object {
 }
 `;
 
+exports[`#185 - acorn.parse - function (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
+Object {
+  "args": Array [
+    "a",
+    "cb",
+    "restArgs",
+  ],
+  "body": "return a * 3",
+  "defaults": Object {
+    "a": "{foo: \\"ba)r\\", baz: 123}",
+    "cb": undefined,
+    "restArgs": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a, cb, restArgs",
+  "value": "(function (a = {foo: \\"ba)r\\", baz: 123}, cb, ...restArgs) {return a * 3})",
+}
+`;
+
 exports[`#186 - acorn.parse - function (a = (true, false)) {} 1`] = `
 Object {
   "args": Array [
@@ -4049,6 +7055,32 @@ Object {
   "name": null,
   "params": "a",
   "value": "(function (a = (true, false)) {})",
+}
+`;
+
+exports[`#186 - acorn.parse - function (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
+Object {
+  "args": Array [
+    "b",
+    "callback",
+    "restArgs",
+  ],
+  "body": "callback(null, b + 3)",
+  "defaults": Object {
+    "b": undefined,
+    "callback": undefined,
+    "restArgs": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "b, callback, restArgs",
+  "value": "(function (b, callback, ...restArgs) {callback(null, b + 3)})",
 }
 `;
 
@@ -4074,6 +7106,50 @@ Object {
 }
 `;
 
+exports[`#187 - acorn.parse - function (c) {return c * 3} 1`] = `
+Object {
+  "args": Array [
+    "c",
+  ],
+  "body": "return c * 3",
+  "defaults": Object {
+    "c": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "c",
+  "value": "(function (c) {return c * 3})",
+}
+`;
+
+exports[`#188 - acorn.parse - function (...restArgs) {return 321} 1`] = `
+Object {
+  "args": Array [
+    "restArgs",
+  ],
+  "body": "return 321",
+  "defaults": Object {
+    "restArgs": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "restArgs",
+  "value": "(function (...restArgs) {return 321})",
+}
+`;
+
 exports[`#188 - acorn.parse - function (a = (true, "bar")) {} 1`] = `
 Object {
   "args": Array [
@@ -4093,6 +7169,24 @@ Object {
   "name": null,
   "params": "a",
   "value": "(function (a = (true, \\"bar\\")) {})",
+}
+`;
+
+exports[`#189 - acorn.parse - function () {} 1`] = `
+Object {
+  "args": Array [],
+  "body": "",
+  "defaults": Object {},
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "",
+  "value": "(function () {})",
 }
 `;
 
@@ -4120,6 +7214,28 @@ Object {
 }
 `;
 
+exports[`#190 - acorn.parse - function (a = (true, false)) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "false",
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "(function (a = (true, false)) {})",
+}
+`;
+
 exports[`#190 - acorn.parse - function (a = 1) {} 1`] = `
 Object {
   "args": Array [
@@ -4139,6 +7255,28 @@ Object {
   "name": null,
   "params": "a",
   "value": "(function (a = 1) {})",
+}
+`;
+
+exports[`#191 - acorn.parse - function (a = (true, null)) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "null",
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "(function (a = (true, null)) {})",
 }
 `;
 
@@ -4168,6 +7306,28 @@ Object {
 }
 `;
 
+exports[`#192 - acorn.parse - function (a = (true, "bar")) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "\\"bar\\"",
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "(function (a = (true, \\"bar\\")) {})",
+}
+`;
+
 exports[`#192 - acorn.parse - function namedFn (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
 Object {
   "args": Array [
@@ -4194,6 +7354,30 @@ Object {
 }
 `;
 
+exports[`#193 - acorn.parse - function (a, b = (i++, true)) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+    "b",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": undefined,
+    "b": "true",
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a, b",
+  "value": "(function (a, b = (i++, true)) {})",
+}
+`;
+
 exports[`#193 - acorn.parse - function namedFn (c) {return c * 3} 1`] = `
 Object {
   "args": Array [
@@ -4213,6 +7397,28 @@ Object {
   "name": "namedFn",
   "params": "c",
   "value": "(function namedFn (c) {return c * 3})",
+}
+`;
+
+exports[`#194 - acorn.parse - function (a = 1) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "1",
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "(function (a = 1) {})",
 }
 `;
 
@@ -4256,6 +7462,58 @@ Object {
 }
 `;
 
+exports[`#195 - acorn.parse - function namedFn (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
+Object {
+  "args": Array [
+    "a",
+    "cb",
+    "restArgs",
+  ],
+  "body": "return a * 3",
+  "defaults": Object {
+    "a": "{foo: \\"ba)r\\", baz: 123}",
+    "cb": undefined,
+    "restArgs": undefined,
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a, cb, restArgs",
+  "value": "(function namedFn (a = {foo: \\"ba)r\\", baz: 123}, cb, ...restArgs) {return a * 3})",
+}
+`;
+
+exports[`#196 - acorn.parse - function namedFn (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
+Object {
+  "args": Array [
+    "b",
+    "callback",
+    "restArgs",
+  ],
+  "body": "callback(null, b + 3)",
+  "defaults": Object {
+    "b": undefined,
+    "callback": undefined,
+    "restArgs": undefined,
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "b, callback, restArgs",
+  "value": "(function namedFn (b, callback, ...restArgs) {callback(null, b + 3)})",
+}
+`;
+
 exports[`#196 - acorn.parse - function namedFn(a = (true, false)) {} 1`] = `
 Object {
   "args": Array [
@@ -4275,6 +7533,28 @@ Object {
   "name": "namedFn",
   "params": "a",
   "value": "(function namedFn(a = (true, false)) {})",
+}
+`;
+
+exports[`#197 - acorn.parse - function namedFn (c) {return c * 3} 1`] = `
+Object {
+  "args": Array [
+    "c",
+  ],
+  "body": "return c * 3",
+  "defaults": Object {
+    "c": undefined,
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "c",
+  "value": "(function namedFn (c) {return c * 3})",
 }
 `;
 
@@ -4300,6 +7580,28 @@ Object {
 }
 `;
 
+exports[`#198 - acorn.parse - function namedFn (...restArgs) {return 321} 1`] = `
+Object {
+  "args": Array [
+    "restArgs",
+  ],
+  "body": "return 321",
+  "defaults": Object {
+    "restArgs": undefined,
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "restArgs",
+  "value": "(function namedFn (...restArgs) {return 321})",
+}
+`;
+
 exports[`#198 - acorn.parse - function namedFn(a = (true, "bar")) {} 1`] = `
 Object {
   "args": Array [
@@ -4319,6 +7621,24 @@ Object {
   "name": "namedFn",
   "params": "a",
   "value": "(function namedFn(a = (true, \\"bar\\")) {})",
+}
+`;
+
+exports[`#199 - acorn.parse - function namedFn () {} 1`] = `
+Object {
+  "args": Array [],
+  "body": "",
+  "defaults": Object {},
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "",
+  "value": "(function namedFn () {})",
 }
 `;
 
@@ -4343,6 +7663,28 @@ Object {
   "name": "namedFn",
   "params": "a, b",
   "value": "(function namedFn(a, b = (i++, true)) {})",
+}
+`;
+
+exports[`#200 - acorn.parse - function namedFn(a = (true, false)) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "false",
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a",
+  "value": "(function namedFn(a = (true, false)) {})",
 }
 `;
 
@@ -4394,6 +7736,28 @@ Object {
 }
 `;
 
+exports[`#201 - acorn.parse - function namedFn(a = (true, null)) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "null",
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a",
+  "value": "(function namedFn(a = (true, null)) {})",
+}
+`;
+
 exports[`#202 - acorn.parse - function * namedFn (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
 Object {
   "args": Array [
@@ -4420,6 +7784,28 @@ Object {
 }
 `;
 
+exports[`#202 - acorn.parse - function namedFn(a = (true, "bar")) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "\\"bar\\"",
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a",
+  "value": "(function namedFn(a = (true, \\"bar\\")) {})",
+}
+`;
+
 exports[`#203 - acorn.parse - function * namedFn (c) {return c * 3} 1`] = `
 Object {
   "args": Array [
@@ -4439,6 +7825,30 @@ Object {
   "name": "namedFn",
   "params": "c",
   "value": "(function * namedFn (c) {return c * 3})",
+}
+`;
+
+exports[`#203 - acorn.parse - function namedFn(a, b = (i++, true)) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+    "b",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": undefined,
+    "b": "true",
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a, b",
+  "value": "(function namedFn(a, b = (i++, true)) {})",
 }
 `;
 
@@ -4464,6 +7874,28 @@ Object {
 }
 `;
 
+exports[`#204 - acorn.parse - function namedFn(a = 1) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "1",
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a",
+  "value": "(function namedFn(a = 1) {})",
+}
+`;
+
 exports[`#205 - acorn.parse - function * namedFn () {} 1`] = `
 Object {
   "args": Array [],
@@ -4479,6 +7911,58 @@ Object {
   "name": "namedFn",
   "params": "",
   "value": "(function * namedFn () {})",
+}
+`;
+
+exports[`#205 - acorn.parse - function * namedFn (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
+Object {
+  "args": Array [
+    "a",
+    "cb",
+    "restArgs",
+  ],
+  "body": "return a * 3",
+  "defaults": Object {
+    "a": "{foo: \\"ba)r\\", baz: 123}",
+    "cb": undefined,
+    "restArgs": undefined,
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": true,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a, cb, restArgs",
+  "value": "(function * namedFn (a = {foo: \\"ba)r\\", baz: 123}, cb, ...restArgs) {return a * 3})",
+}
+`;
+
+exports[`#206 - acorn.parse - function * namedFn (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
+Object {
+  "args": Array [
+    "b",
+    "callback",
+    "restArgs",
+  ],
+  "body": "callback(null, b + 3)",
+  "defaults": Object {
+    "b": undefined,
+    "callback": undefined,
+    "restArgs": undefined,
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": true,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "b, callback, restArgs",
+  "value": "(function * namedFn (b, callback, ...restArgs) {callback(null, b + 3)})",
 }
 `;
 
@@ -4504,6 +7988,28 @@ Object {
 }
 `;
 
+exports[`#207 - acorn.parse - function * namedFn (c) {return c * 3} 1`] = `
+Object {
+  "args": Array [
+    "c",
+  ],
+  "body": "return c * 3",
+  "defaults": Object {
+    "c": undefined,
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": true,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "c",
+  "value": "(function * namedFn (c) {return c * 3})",
+}
+`;
+
 exports[`#207 - acorn.parse - function * namedFn(a = (true, null)) {} 1`] = `
 Object {
   "args": Array [
@@ -4523,6 +8029,28 @@ Object {
   "name": "namedFn",
   "params": "a",
   "value": "(function * namedFn(a = (true, null)) {})",
+}
+`;
+
+exports[`#208 - acorn.parse - function * namedFn (...restArgs) {return 321} 1`] = `
+Object {
+  "args": Array [
+    "restArgs",
+  ],
+  "body": "return 321",
+  "defaults": Object {
+    "restArgs": undefined,
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": true,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "restArgs",
+  "value": "(function * namedFn (...restArgs) {return 321})",
 }
 `;
 
@@ -4548,6 +8076,24 @@ Object {
 }
 `;
 
+exports[`#209 - acorn.parse - function * namedFn () {} 1`] = `
+Object {
+  "args": Array [],
+  "body": "",
+  "defaults": Object {},
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": true,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "",
+  "value": "(function * namedFn () {})",
+}
+`;
+
 exports[`#209 - acorn.parse - function * namedFn(a, b = (i++, true)) {} 1`] = `
 Object {
   "args": Array [
@@ -4569,6 +8115,28 @@ Object {
   "name": "namedFn",
   "params": "a, b",
   "value": "(function * namedFn(a, b = (i++, true)) {})",
+}
+`;
+
+exports[`#210 - acorn.parse - function * namedFn(a = (true, false)) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "false",
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": true,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a",
+  "value": "(function * namedFn(a = (true, false)) {})",
 }
 `;
 
@@ -4620,6 +8188,28 @@ Object {
 }
 `;
 
+exports[`#211 - acorn.parse - function * namedFn(a = (true, null)) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "null",
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": true,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a",
+  "value": "(function * namedFn(a = (true, null)) {})",
+}
+`;
+
 exports[`#212 - acorn.parse - (b, callback, ...restArgs) => {callback(null, b + 3)} 1`] = `
 Object {
   "args": Array [
@@ -4646,6 +8236,28 @@ Object {
 }
 `;
 
+exports[`#212 - acorn.parse - function * namedFn(a = (true, "bar")) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "\\"bar\\"",
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": true,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a",
+  "value": "(function * namedFn(a = (true, \\"bar\\")) {})",
+}
+`;
+
 exports[`#213 - acorn.parse - (c) => {return c * 3} 1`] = `
 Object {
   "args": Array [
@@ -4665,6 +8277,30 @@ Object {
   "name": null,
   "params": "c",
   "value": "((c) => {return c * 3})",
+}
+`;
+
+exports[`#213 - acorn.parse - function * namedFn(a, b = (i++, true)) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+    "b",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": undefined,
+    "b": "true",
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": true,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a, b",
+  "value": "(function * namedFn(a, b = (i++, true)) {})",
 }
 `;
 
@@ -4690,6 +8326,28 @@ Object {
 }
 `;
 
+exports[`#214 - acorn.parse - function * namedFn(a = 1) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "1",
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": true,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a",
+  "value": "(function * namedFn(a = 1) {})",
+}
+`;
+
 exports[`#215 - acorn.parse - () => {} 1`] = `
 Object {
   "args": Array [],
@@ -4705,6 +8363,32 @@ Object {
   "name": null,
   "params": "",
   "value": "(() => {})",
+}
+`;
+
+exports[`#215 - acorn.parse - (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) => {return a * 3} 1`] = `
+Object {
+  "args": Array [
+    "a",
+    "cb",
+    "restArgs",
+  ],
+  "body": "return a * 3",
+  "defaults": Object {
+    "a": "{foo: \\"ba)r\\", baz: 123}",
+    "cb": undefined,
+    "restArgs": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a, cb, restArgs",
+  "value": "((a = {foo: \\"ba)r\\", baz: 123}, cb, ...restArgs) => {return a * 3})",
 }
 `;
 
@@ -4730,6 +8414,32 @@ Object {
 }
 `;
 
+exports[`#216 - acorn.parse - (b, callback, ...restArgs) => {callback(null, b + 3)} 1`] = `
+Object {
+  "args": Array [
+    "b",
+    "callback",
+    "restArgs",
+  ],
+  "body": "callback(null, b + 3)",
+  "defaults": Object {
+    "b": undefined,
+    "callback": undefined,
+    "restArgs": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "b, callback, restArgs",
+  "value": "((b, callback, ...restArgs) => {callback(null, b + 3)})",
+}
+`;
+
 exports[`#217 - acorn.parse - (a = (true, null)) => {} 1`] = `
 Object {
   "args": Array [
@@ -4752,6 +8462,50 @@ Object {
 }
 `;
 
+exports[`#217 - acorn.parse - (c) => {return c * 3} 1`] = `
+Object {
+  "args": Array [
+    "c",
+  ],
+  "body": "return c * 3",
+  "defaults": Object {
+    "c": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "c",
+  "value": "((c) => {return c * 3})",
+}
+`;
+
+exports[`#218 - acorn.parse - (...restArgs) => {return 321} 1`] = `
+Object {
+  "args": Array [
+    "restArgs",
+  ],
+  "body": "return 321",
+  "defaults": Object {
+    "restArgs": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "restArgs",
+  "value": "((...restArgs) => {return 321})",
+}
+`;
+
 exports[`#218 - acorn.parse - (a = (true, "bar")) => {} 1`] = `
 Object {
   "args": Array [
@@ -4771,6 +8525,24 @@ Object {
   "name": null,
   "params": "a",
   "value": "((a = (true, \\"bar\\")) => {})",
+}
+`;
+
+exports[`#219 - acorn.parse - () => {} 1`] = `
+Object {
+  "args": Array [],
+  "body": "",
+  "defaults": Object {},
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "",
+  "value": "(() => {})",
 }
 `;
 
@@ -4798,6 +8570,28 @@ Object {
 }
 `;
 
+exports[`#220 - acorn.parse - (a = (true, false)) => {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "false",
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "((a = (true, false)) => {})",
+}
+`;
+
 exports[`#220 - acorn.parse - (a = 1) => {} 1`] = `
 Object {
   "args": Array [
@@ -4817,6 +8611,28 @@ Object {
   "name": null,
   "params": "a",
   "value": "((a = 1) => {})",
+}
+`;
+
+exports[`#221 - acorn.parse - (a = (true, null)) => {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "null",
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "((a = (true, null)) => {})",
 }
 `;
 
@@ -4842,6 +8658,28 @@ Object {
 }
 `;
 
+exports[`#222 - acorn.parse - (a = (true, "bar")) => {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "\\"bar\\"",
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "((a = (true, \\"bar\\")) => {})",
+}
+`;
+
 exports[`#222 - acorn.parse - d => d * 355 * d 1`] = `
 Object {
   "args": Array [
@@ -4861,6 +8699,30 @@ Object {
   "name": null,
   "params": "d",
   "value": "(d => d * 355 * d)",
+}
+`;
+
+exports[`#223 - acorn.parse - (a, b = (i++, true)) => {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+    "b",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": undefined,
+    "b": "true",
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a, b",
+  "value": "((a, b = (i++, true)) => {})",
 }
 `;
 
@@ -4886,6 +8748,28 @@ Object {
 }
 `;
 
+exports[`#224 - acorn.parse - (a = 1) => {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "1",
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "((a = 1) => {})",
+}
+`;
+
 exports[`#224 - acorn.parse - (a, b) => a + 3 + b 1`] = `
 Object {
   "args": Array [
@@ -4907,6 +8791,28 @@ Object {
   "name": null,
   "params": "a, b",
   "value": "((a, b) => a + 3 + b)",
+}
+`;
+
+exports[`#225 - acorn.parse - (a) => a * 3 * a 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "a * 3 * a",
+  "defaults": Object {
+    "a": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": false,
+  "isExpression": true,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "((a) => a * 3 * a)",
 }
 `;
 
@@ -4962,6 +8868,28 @@ Object {
 }
 `;
 
+exports[`#226 - acorn.parse - d => d * 355 * d 1`] = `
+Object {
+  "args": Array [
+    "d",
+  ],
+  "body": "d * 355 * d",
+  "defaults": Object {
+    "d": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": false,
+  "isExpression": true,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "d",
+  "value": "(d => d * 355 * d)",
+}
+`;
+
 exports[`#227 - acorn.parse - async function (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
 Object {
   "args": Array [
@@ -4988,6 +8916,52 @@ Object {
 }
 `;
 
+exports[`#227 - acorn.parse - e => {return e + 5235 / e} 1`] = `
+Object {
+  "args": Array [
+    "e",
+  ],
+  "body": "return e + 5235 / e",
+  "defaults": Object {
+    "e": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "e",
+  "value": "(e => {return e + 5235 / e})",
+}
+`;
+
+exports[`#228 - acorn.parse - (a, b) => a + 3 + b 1`] = `
+Object {
+  "args": Array [
+    "a",
+    "b",
+  ],
+  "body": "a + 3 + b",
+  "defaults": Object {
+    "a": undefined,
+    "b": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": false,
+  "isExpression": true,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a, b",
+  "value": "((a, b) => a + 3 + b)",
+}
+`;
+
 exports[`#228 - acorn.parse - async function (c) {return c * 3} 1`] = `
 Object {
   "args": Array [
@@ -5010,6 +8984,32 @@ Object {
 }
 `;
 
+exports[`#229 - acorn.parse - (x, y, ...restArgs) => console.log({ value: x * y }) 1`] = `
+Object {
+  "args": Array [
+    "x",
+    "y",
+    "restArgs",
+  ],
+  "body": "console.log({ value: x * y })",
+  "defaults": Object {
+    "restArgs": undefined,
+    "x": undefined,
+    "y": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": false,
+  "isExpression": true,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "x, y, restArgs",
+  "value": "((x, y, ...restArgs) => console.log({ value: x * y }))",
+}
+`;
+
 exports[`#229 - acorn.parse - async function (...restArgs) {return 321} 1`] = `
 Object {
   "args": Array [
@@ -5029,6 +9029,27 @@ Object {
   "name": null,
   "params": "restArgs",
   "value": "(async function (...restArgs) {return 321})",
+}
+`;
+
+exports[`#230 - acorn.parse - ({x, y}) => {} 1`] = `
+Object {
+  "args": Array [
+    "x",
+    "y",
+  ],
+  "body": "",
+  "defaults": Object {},
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "x, y",
+  "value": "(({x, y}) => {})",
 }
 `;
 
@@ -5072,6 +9093,32 @@ Object {
 }
 `;
 
+exports[`#231 - acorn.parse - async function (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
+Object {
+  "args": Array [
+    "a",
+    "cb",
+    "restArgs",
+  ],
+  "body": "return a * 3",
+  "defaults": Object {
+    "a": "{foo: \\"ba)r\\", baz: 123}",
+    "cb": undefined,
+    "restArgs": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a, cb, restArgs",
+  "value": "(async function (a = {foo: \\"ba)r\\", baz: 123}, cb, ...restArgs) {return a * 3})",
+}
+`;
+
 exports[`#232 - acorn.parse - async function (a = (true, null)) {} 1`] = `
 Object {
   "args": Array [
@@ -5094,6 +9141,32 @@ Object {
 }
 `;
 
+exports[`#232 - acorn.parse - async function (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
+Object {
+  "args": Array [
+    "b",
+    "callback",
+    "restArgs",
+  ],
+  "body": "callback(null, b + 3)",
+  "defaults": Object {
+    "b": undefined,
+    "callback": undefined,
+    "restArgs": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "b, callback, restArgs",
+  "value": "(async function (b, callback, ...restArgs) {callback(null, b + 3)})",
+}
+`;
+
 exports[`#233 - acorn.parse - async function (a = (true, "bar")) {} 1`] = `
 Object {
   "args": Array [
@@ -5113,6 +9186,50 @@ Object {
   "name": null,
   "params": "a",
   "value": "(async function (a = (true, \\"bar\\")) {})",
+}
+`;
+
+exports[`#233 - acorn.parse - async function (c) {return c * 3} 1`] = `
+Object {
+  "args": Array [
+    "c",
+  ],
+  "body": "return c * 3",
+  "defaults": Object {
+    "c": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "c",
+  "value": "(async function (c) {return c * 3})",
+}
+`;
+
+exports[`#234 - acorn.parse - async function (...restArgs) {return 321} 1`] = `
+Object {
+  "args": Array [
+    "restArgs",
+  ],
+  "body": "return 321",
+  "defaults": Object {
+    "restArgs": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "restArgs",
+  "value": "(async function (...restArgs) {return 321})",
 }
 `;
 
@@ -5140,6 +9257,24 @@ Object {
 }
 `;
 
+exports[`#235 - acorn.parse - async function () {} 1`] = `
+Object {
+  "args": Array [],
+  "body": "",
+  "defaults": Object {},
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "",
+  "value": "(async function () {})",
+}
+`;
+
 exports[`#235 - acorn.parse - async function (a = 1) {} 1`] = `
 Object {
   "args": Array [
@@ -5159,6 +9294,28 @@ Object {
   "name": null,
   "params": "a",
   "value": "(async function (a = 1) {})",
+}
+`;
+
+exports[`#236 - acorn.parse - async function (a = (true, false)) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "false",
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "(async function (a = (true, false)) {})",
 }
 `;
 
@@ -5188,6 +9345,28 @@ Object {
 }
 `;
 
+exports[`#237 - acorn.parse - async function (a = (true, null)) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "null",
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "(async function (a = (true, null)) {})",
+}
+`;
+
 exports[`#237 - acorn.parse - async function namedFn (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
 Object {
   "args": Array [
@@ -5214,6 +9393,28 @@ Object {
 }
 `;
 
+exports[`#238 - acorn.parse - async function (a = (true, "bar")) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "\\"bar\\"",
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "(async function (a = (true, \\"bar\\")) {})",
+}
+`;
+
 exports[`#238 - acorn.parse - async function namedFn (c) {return c * 3} 1`] = `
 Object {
   "args": Array [
@@ -5233,6 +9434,30 @@ Object {
   "name": "namedFn",
   "params": "c",
   "value": "(async function namedFn (c) {return c * 3})",
+}
+`;
+
+exports[`#239 - acorn.parse - async function (a, b = (i++, true)) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+    "b",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": undefined,
+    "b": "true",
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a, b",
+  "value": "(async function (a, b = (i++, true)) {})",
 }
 `;
 
@@ -5258,6 +9483,28 @@ Object {
 }
 `;
 
+exports[`#240 - acorn.parse - async function (a = 1) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "1",
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "(async function (a = 1) {})",
+}
+`;
+
 exports[`#240 - acorn.parse - async function namedFn () {} 1`] = `
 Object {
   "args": Array [],
@@ -5273,6 +9520,32 @@ Object {
   "name": "namedFn",
   "params": "",
   "value": "(async function namedFn () {})",
+}
+`;
+
+exports[`#241 - acorn.parse - async function namedFn (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
+Object {
+  "args": Array [
+    "a",
+    "cb",
+    "restArgs",
+  ],
+  "body": "return a * 3",
+  "defaults": Object {
+    "a": "{foo: \\"ba)r\\", baz: 123}",
+    "cb": undefined,
+    "restArgs": undefined,
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a, cb, restArgs",
+  "value": "(async function namedFn (a = {foo: \\"ba)r\\", baz: 123}, cb, ...restArgs) {return a * 3})",
 }
 `;
 
@@ -5298,6 +9571,32 @@ Object {
 }
 `;
 
+exports[`#242 - acorn.parse - async function namedFn (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
+Object {
+  "args": Array [
+    "b",
+    "callback",
+    "restArgs",
+  ],
+  "body": "callback(null, b + 3)",
+  "defaults": Object {
+    "b": undefined,
+    "callback": undefined,
+    "restArgs": undefined,
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "b, callback, restArgs",
+  "value": "(async function namedFn (b, callback, ...restArgs) {callback(null, b + 3)})",
+}
+`;
+
 exports[`#242 - acorn.parse - async function namedFn(a = (true, null)) {} 1`] = `
 Object {
   "args": Array [
@@ -5317,6 +9616,28 @@ Object {
   "name": "namedFn",
   "params": "a",
   "value": "(async function namedFn(a = (true, null)) {})",
+}
+`;
+
+exports[`#243 - acorn.parse - async function namedFn (c) {return c * 3} 1`] = `
+Object {
+  "args": Array [
+    "c",
+  ],
+  "body": "return c * 3",
+  "defaults": Object {
+    "c": undefined,
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "c",
+  "value": "(async function namedFn (c) {return c * 3})",
 }
 `;
 
@@ -5342,6 +9663,28 @@ Object {
 }
 `;
 
+exports[`#244 - acorn.parse - async function namedFn (...restArgs) {return 321} 1`] = `
+Object {
+  "args": Array [
+    "restArgs",
+  ],
+  "body": "return 321",
+  "defaults": Object {
+    "restArgs": undefined,
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "restArgs",
+  "value": "(async function namedFn (...restArgs) {return 321})",
+}
+`;
+
 exports[`#244 - acorn.parse - async function namedFn(a, b = (i++, true)) {} 1`] = `
 Object {
   "args": Array [
@@ -5363,6 +9706,24 @@ Object {
   "name": "namedFn",
   "params": "a, b",
   "value": "(async function namedFn(a, b = (i++, true)) {})",
+}
+`;
+
+exports[`#245 - acorn.parse - async function namedFn () {} 1`] = `
+Object {
+  "args": Array [],
+  "body": "",
+  "defaults": Object {},
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "",
+  "value": "(async function namedFn () {})",
 }
 `;
 
@@ -5414,6 +9775,28 @@ Object {
 }
 `;
 
+exports[`#246 - acorn.parse - async function namedFn(a = (true, false)) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "false",
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a",
+  "value": "(async function namedFn(a = (true, false)) {})",
+}
+`;
+
 exports[`#247 - acorn.parse - async (b, callback, ...restArgs) => {callback(null, b + 3)} 1`] = `
 Object {
   "args": Array [
@@ -5440,6 +9823,28 @@ Object {
 }
 `;
 
+exports[`#247 - acorn.parse - async function namedFn(a = (true, null)) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "null",
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a",
+  "value": "(async function namedFn(a = (true, null)) {})",
+}
+`;
+
 exports[`#248 - acorn.parse - async (c) => {return c * 3} 1`] = `
 Object {
   "args": Array [
@@ -5459,6 +9864,28 @@ Object {
   "name": null,
   "params": "c",
   "value": "(async (c) => {return c * 3})",
+}
+`;
+
+exports[`#248 - acorn.parse - async function namedFn(a = (true, "bar")) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "\\"bar\\"",
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a",
+  "value": "(async function namedFn(a = (true, \\"bar\\")) {})",
 }
 `;
 
@@ -5484,6 +9911,30 @@ Object {
 }
 `;
 
+exports[`#249 - acorn.parse - async function namedFn(a, b = (i++, true)) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+    "b",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": undefined,
+    "b": "true",
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a, b",
+  "value": "(async function namedFn(a, b = (i++, true)) {})",
+}
+`;
+
 exports[`#250 - acorn.parse - async () => {} 1`] = `
 Object {
   "args": Array [],
@@ -5499,6 +9950,28 @@ Object {
   "name": null,
   "params": "",
   "value": "(async () => {})",
+}
+`;
+
+exports[`#250 - acorn.parse - async function namedFn(a = 1) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "1",
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a",
+  "value": "(async function namedFn(a = 1) {})",
 }
 `;
 
@@ -5524,6 +9997,32 @@ Object {
 }
 `;
 
+exports[`#251 - acorn.parse - async (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) => {return a * 3} 1`] = `
+Object {
+  "args": Array [
+    "a",
+    "cb",
+    "restArgs",
+  ],
+  "body": "return a * 3",
+  "defaults": Object {
+    "a": "{foo: \\"ba)r\\", baz: 123}",
+    "cb": undefined,
+    "restArgs": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a, cb, restArgs",
+  "value": "(async (a = {foo: \\"ba)r\\", baz: 123}, cb, ...restArgs) => {return a * 3})",
+}
+`;
+
 exports[`#252 - acorn.parse - async (a = (true, null)) => {} 1`] = `
 Object {
   "args": Array [
@@ -5546,6 +10045,32 @@ Object {
 }
 `;
 
+exports[`#252 - acorn.parse - async (b, callback, ...restArgs) => {callback(null, b + 3)} 1`] = `
+Object {
+  "args": Array [
+    "b",
+    "callback",
+    "restArgs",
+  ],
+  "body": "callback(null, b + 3)",
+  "defaults": Object {
+    "b": undefined,
+    "callback": undefined,
+    "restArgs": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "b, callback, restArgs",
+  "value": "(async (b, callback, ...restArgs) => {callback(null, b + 3)})",
+}
+`;
+
 exports[`#253 - acorn.parse - async (a = (true, "bar")) => {} 1`] = `
 Object {
   "args": Array [
@@ -5565,6 +10090,50 @@ Object {
   "name": null,
   "params": "a",
   "value": "(async (a = (true, \\"bar\\")) => {})",
+}
+`;
+
+exports[`#253 - acorn.parse - async (c) => {return c * 3} 1`] = `
+Object {
+  "args": Array [
+    "c",
+  ],
+  "body": "return c * 3",
+  "defaults": Object {
+    "c": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "c",
+  "value": "(async (c) => {return c * 3})",
+}
+`;
+
+exports[`#254 - acorn.parse - async (...restArgs) => {return 321} 1`] = `
+Object {
+  "args": Array [
+    "restArgs",
+  ],
+  "body": "return 321",
+  "defaults": Object {
+    "restArgs": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "restArgs",
+  "value": "(async (...restArgs) => {return 321})",
 }
 `;
 
@@ -5592,6 +10161,24 @@ Object {
 }
 `;
 
+exports[`#255 - acorn.parse - async () => {} 1`] = `
+Object {
+  "args": Array [],
+  "body": "",
+  "defaults": Object {},
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "",
+  "value": "(async () => {})",
+}
+`;
+
 exports[`#255 - acorn.parse - async (a = 1) => {} 1`] = `
 Object {
   "args": Array [
@@ -5611,6 +10198,28 @@ Object {
   "name": null,
   "params": "a",
   "value": "(async (a = 1) => {})",
+}
+`;
+
+exports[`#256 - acorn.parse - async (a = (true, false)) => {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "false",
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "(async (a = (true, false)) => {})",
 }
 `;
 
@@ -5636,6 +10245,28 @@ Object {
 }
 `;
 
+exports[`#257 - acorn.parse - async (a = (true, null)) => {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "null",
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "(async (a = (true, null)) => {})",
+}
+`;
+
 exports[`#257 - acorn.parse - async d => d * 355 * d 1`] = `
 Object {
   "args": Array [
@@ -5655,6 +10286,28 @@ Object {
   "name": null,
   "params": "d",
   "value": "(async d => d * 355 * d)",
+}
+`;
+
+exports[`#258 - acorn.parse - async (a = (true, "bar")) => {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "\\"bar\\"",
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "(async (a = (true, \\"bar\\")) => {})",
 }
 `;
 
@@ -5680,6 +10333,30 @@ Object {
 }
 `;
 
+exports[`#259 - acorn.parse - async (a, b = (i++, true)) => {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+    "b",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": undefined,
+    "b": "true",
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a, b",
+  "value": "(async (a, b = (i++, true)) => {})",
+}
+`;
+
 exports[`#259 - acorn.parse - async (a, b) => a + 3 + b 1`] = `
 Object {
   "args": Array [
@@ -5701,6 +10378,28 @@ Object {
   "name": null,
   "params": "a, b",
   "value": "(async (a, b) => a + 3 + b)",
+}
+`;
+
+exports[`#260 - acorn.parse - async (a = 1) => {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "1",
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "(async (a = 1) => {})",
 }
 `;
 
@@ -5730,6 +10429,28 @@ Object {
 }
 `;
 
+exports[`#261 - acorn.parse - async (a) => a * 3 * a 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "a * 3 * a",
+  "defaults": Object {
+    "a": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": true,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "(async (a) => a * 3 * a)",
+}
+`;
+
 exports[`#261 - acorn.parse - should return object with default values when invalid 1`] = `
 Object {
   "args": Array [],
@@ -5748,7 +10469,140 @@ Object {
 }
 `;
 
+exports[`#262 - acorn.parse - async d => d * 355 * d 1`] = `
+Object {
+  "args": Array [
+    "d",
+  ],
+  "body": "d * 355 * d",
+  "defaults": Object {
+    "d": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": true,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "d",
+  "value": "(async d => d * 355 * d)",
+}
+`;
+
 exports[`#262 - acorn.parse - should have '.isValid' and few '.is*'' hidden properties 1`] = `
+Object {
+  "args": Array [],
+  "body": "",
+  "defaults": Object {},
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": false,
+  "name": null,
+  "params": "",
+  "value": "",
+}
+`;
+
+exports[`#263 - acorn.parse - async e => {return e + 5235 / e} 1`] = `
+Object {
+  "args": Array [
+    "e",
+  ],
+  "body": "return e + 5235 / e",
+  "defaults": Object {
+    "e": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "e",
+  "value": "(async e => {return e + 5235 / e})",
+}
+`;
+
+exports[`#264 - acorn.parse - async (a, b) => a + 3 + b 1`] = `
+Object {
+  "args": Array [
+    "a",
+    "b",
+  ],
+  "body": "a + 3 + b",
+  "defaults": Object {
+    "a": undefined,
+    "b": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": true,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a, b",
+  "value": "(async (a, b) => a + 3 + b)",
+}
+`;
+
+exports[`#265 - acorn.parse - async (x, y, ...restArgs) => console.log({ value: x * y }) 1`] = `
+Object {
+  "args": Array [
+    "x",
+    "y",
+    "restArgs",
+  ],
+  "body": "console.log({ value: x * y })",
+  "defaults": Object {
+    "restArgs": undefined,
+    "x": undefined,
+    "y": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": true,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "x, y, restArgs",
+  "value": "(async (x, y, ...restArgs) => console.log({ value: x * y }))",
+}
+`;
+
+exports[`#266 - acorn.parse - async ({x, y}) => {} 1`] = `
+Object {
+  "args": Array [
+    "x",
+    "y",
+  ],
+  "body": "",
+  "defaults": Object {},
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "x, y",
+  "value": "(async ({x, y}) => {})",
+}
+`;
+
+exports[`#267 - acorn.parse - should return object with default values when invalid 1`] = `
 Object {
   "args": Array [],
   "body": "",
@@ -5874,6 +10728,24 @@ Object {
 }
 `;
 
+exports[`#268 - acorn.parse - should have '.isValid' and few '.is*'' hidden properties 1`] = `
+Object {
+  "args": Array [],
+  "body": "",
+  "defaults": Object {},
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": false,
+  "name": null,
+  "params": "",
+  "value": "",
+}
+`;
+
 exports[`#271 - acorn loose - function (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
 Object {
   "args": Array [
@@ -5945,6 +10817,114 @@ Object {
   "name": null,
   "params": "c",
   "value": "(function (c) {return c * 3})",
+}
+`;
+
+exports[`#273 - acorn.parse - should work for object methods 1`] = `
+Object {
+  "args": Array [
+    "a",
+    "b",
+    "c",
+  ],
+  "body": "
+        return 123;
+      ",
+  "defaults": Object {
+    "a": undefined,
+    "b": undefined,
+    "c": undefined,
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "foo",
+  "params": "a, b, c",
+  "value": "({ foo(a, b, c) {
+        return 123;
+      } })",
+}
+`;
+
+exports[`#273 - acorn.parse - should work for object methods 2`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "
+        return () => a;
+      ",
+  "defaults": Object {
+    "a": undefined,
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "bar",
+  "params": "a",
+  "value": "({ bar(a) {
+        return () => a;
+      } })",
+}
+`;
+
+exports[`#273 - acorn.parse - should work for object methods 3`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "
+        return yield a * 321;
+      ",
+  "defaults": Object {
+    "a": undefined,
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": true,
+  "isNamed": true,
+  "isValid": true,
+  "name": "gen",
+  "params": "a",
+  "value": "({ *gen(a) {
+        return yield a * 321;
+      } })",
+}
+`;
+
+exports[`#273 - acorn.parse - should work for object methods 4`] = `
+Object {
+  "args": Array [
+    "a",
+    "cb",
+    "restArgs",
+  ],
+  "body": " return a * 3 ",
+  "defaults": Object {
+    "a": "{foo: 'ba)r', baz: 123}",
+    "cb": undefined,
+    "restArgs": undefined,
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a, cb, restArgs",
+  "value": "({ namedFn (a = {foo: 'ba)r', baz: 123}, cb, ...restArgs) { return a * 3 } })",
 }
 `;
 
@@ -6032,6 +11012,32 @@ Object {
 }
 `;
 
+exports[`#277 - acorn loose - function (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
+Object {
+  "args": Array [
+    "a",
+    "cb",
+    "restArgs",
+  ],
+  "body": "return a * 3",
+  "defaults": Object {
+    "a": "{foo: \\"ba)r\\", baz: 123}",
+    "cb": undefined,
+    "restArgs": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a, cb, restArgs",
+  "value": "(function (a = {foo: \\"ba)r\\", baz: 123}, cb, ...restArgs) {return a * 3})",
+}
+`;
+
 exports[`#278 - acorn loose - function (a = (true, "bar")) {} 1`] = `
 Object {
   "args": Array [
@@ -6051,6 +11057,32 @@ Object {
   "name": null,
   "params": "a",
   "value": "(function (a = (true, \\"bar\\")) {})",
+}
+`;
+
+exports[`#278 - acorn loose - function (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
+Object {
+  "args": Array [
+    "b",
+    "callback",
+    "restArgs",
+  ],
+  "body": "callback(null, b + 3)",
+  "defaults": Object {
+    "b": undefined,
+    "callback": undefined,
+    "restArgs": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "b, callback, restArgs",
+  "value": "(function (b, callback, ...restArgs) {callback(null, b + 3)})",
 }
 `;
 
@@ -6078,6 +11110,50 @@ Object {
 }
 `;
 
+exports[`#279 - acorn loose - function (c) {return c * 3} 1`] = `
+Object {
+  "args": Array [
+    "c",
+  ],
+  "body": "return c * 3",
+  "defaults": Object {
+    "c": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "c",
+  "value": "(function (c) {return c * 3})",
+}
+`;
+
+exports[`#280 - acorn loose - function (...restArgs) {return 321} 1`] = `
+Object {
+  "args": Array [
+    "restArgs",
+  ],
+  "body": "return 321",
+  "defaults": Object {
+    "restArgs": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "restArgs",
+  "value": "(function (...restArgs) {return 321})",
+}
+`;
+
 exports[`#280 - acorn loose - function (a = 1) {} 1`] = `
 Object {
   "args": Array [
@@ -6097,6 +11173,24 @@ Object {
   "name": null,
   "params": "a",
   "value": "(function (a = 1) {})",
+}
+`;
+
+exports[`#281 - acorn loose - function () {} 1`] = `
+Object {
+  "args": Array [],
+  "body": "",
+  "defaults": Object {},
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "",
+  "value": "(function () {})",
 }
 `;
 
@@ -6126,6 +11220,28 @@ Object {
 }
 `;
 
+exports[`#282 - acorn loose - function (a = (true, false)) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "false",
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "(function (a = (true, false)) {})",
+}
+`;
+
 exports[`#282 - acorn loose - function namedFn (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
 Object {
   "args": Array [
@@ -6152,6 +11268,28 @@ Object {
 }
 `;
 
+exports[`#283 - acorn loose - function (a = (true, null)) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "null",
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "(function (a = (true, null)) {})",
+}
+`;
+
 exports[`#283 - acorn loose - function namedFn (c) {return c * 3} 1`] = `
 Object {
   "args": Array [
@@ -6171,6 +11309,28 @@ Object {
   "name": "namedFn",
   "params": "c",
   "value": "(function namedFn (c) {return c * 3})",
+}
+`;
+
+exports[`#284 - acorn loose - function (a = (true, "bar")) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "\\"bar\\"",
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "(function (a = (true, \\"bar\\")) {})",
 }
 `;
 
@@ -6196,6 +11356,30 @@ Object {
 }
 `;
 
+exports[`#285 - acorn loose - function (a, b = (i++, true)) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+    "b",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": undefined,
+    "b": "true",
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a, b",
+  "value": "(function (a, b = (i++, true)) {})",
+}
+`;
+
 exports[`#285 - acorn loose - function namedFn () {} 1`] = `
 Object {
   "args": Array [],
@@ -6211,6 +11395,28 @@ Object {
   "name": "namedFn",
   "params": "",
   "value": "(function namedFn () {})",
+}
+`;
+
+exports[`#286 - acorn loose - function (a = 1) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "1",
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "(function (a = 1) {})",
 }
 `;
 
@@ -6236,6 +11442,32 @@ Object {
 }
 `;
 
+exports[`#287 - acorn loose - function namedFn (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
+Object {
+  "args": Array [
+    "a",
+    "cb",
+    "restArgs",
+  ],
+  "body": "return a * 3",
+  "defaults": Object {
+    "a": "{foo: \\"ba)r\\", baz: 123}",
+    "cb": undefined,
+    "restArgs": undefined,
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a, cb, restArgs",
+  "value": "(function namedFn (a = {foo: \\"ba)r\\", baz: 123}, cb, ...restArgs) {return a * 3})",
+}
+`;
+
 exports[`#287 - acorn loose - function namedFn(a = (true, null)) {} 1`] = `
 Object {
   "args": Array [
@@ -6255,6 +11487,32 @@ Object {
   "name": "namedFn",
   "params": "a",
   "value": "(function namedFn(a = (true, null)) {})",
+}
+`;
+
+exports[`#288 - acorn loose - function namedFn (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
+Object {
+  "args": Array [
+    "b",
+    "callback",
+    "restArgs",
+  ],
+  "body": "callback(null, b + 3)",
+  "defaults": Object {
+    "b": undefined,
+    "callback": undefined,
+    "restArgs": undefined,
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "b, callback, restArgs",
+  "value": "(function namedFn (b, callback, ...restArgs) {callback(null, b + 3)})",
 }
 `;
 
@@ -6280,6 +11538,28 @@ Object {
 }
 `;
 
+exports[`#289 - acorn loose - function namedFn (c) {return c * 3} 1`] = `
+Object {
+  "args": Array [
+    "c",
+  ],
+  "body": "return c * 3",
+  "defaults": Object {
+    "c": undefined,
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "c",
+  "value": "(function namedFn (c) {return c * 3})",
+}
+`;
+
 exports[`#289 - acorn loose - function namedFn(a, b = (i++, true)) {} 1`] = `
 Object {
   "args": Array [
@@ -6301,6 +11581,28 @@ Object {
   "name": "namedFn",
   "params": "a, b",
   "value": "(function namedFn(a, b = (i++, true)) {})",
+}
+`;
+
+exports[`#290 - acorn loose - function namedFn (...restArgs) {return 321} 1`] = `
+Object {
+  "args": Array [
+    "restArgs",
+  ],
+  "body": "return 321",
+  "defaults": Object {
+    "restArgs": undefined,
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "restArgs",
+  "value": "(function namedFn (...restArgs) {return 321})",
 }
 `;
 
@@ -6352,6 +11654,24 @@ Object {
 }
 `;
 
+exports[`#291 - acorn loose - function namedFn () {} 1`] = `
+Object {
+  "args": Array [],
+  "body": "",
+  "defaults": Object {},
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "",
+  "value": "(function namedFn () {})",
+}
+`;
+
 exports[`#292 - acorn loose - function * namedFn (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
 Object {
   "args": Array [
@@ -6378,6 +11698,28 @@ Object {
 }
 `;
 
+exports[`#292 - acorn loose - function namedFn(a = (true, false)) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "false",
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a",
+  "value": "(function namedFn(a = (true, false)) {})",
+}
+`;
+
 exports[`#293 - acorn loose - function * namedFn (c) {return c * 3} 1`] = `
 Object {
   "args": Array [
@@ -6397,6 +11739,28 @@ Object {
   "name": "namedFn",
   "params": "c",
   "value": "(function * namedFn (c) {return c * 3})",
+}
+`;
+
+exports[`#293 - acorn loose - function namedFn(a = (true, null)) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "null",
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a",
+  "value": "(function namedFn(a = (true, null)) {})",
 }
 `;
 
@@ -6422,6 +11786,28 @@ Object {
 }
 `;
 
+exports[`#294 - acorn loose - function namedFn(a = (true, "bar")) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "\\"bar\\"",
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a",
+  "value": "(function namedFn(a = (true, \\"bar\\")) {})",
+}
+`;
+
 exports[`#295 - acorn loose - function * namedFn () {} 1`] = `
 Object {
   "args": Array [],
@@ -6437,6 +11823,30 @@ Object {
   "name": "namedFn",
   "params": "",
   "value": "(function * namedFn () {})",
+}
+`;
+
+exports[`#295 - acorn loose - function namedFn(a, b = (i++, true)) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+    "b",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": undefined,
+    "b": "true",
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a, b",
+  "value": "(function namedFn(a, b = (i++, true)) {})",
 }
 `;
 
@@ -6462,6 +11872,54 @@ Object {
 }
 `;
 
+exports[`#296 - acorn loose - function namedFn(a = 1) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "1",
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a",
+  "value": "(function namedFn(a = 1) {})",
+}
+`;
+
+exports[`#297 - acorn loose - function * namedFn (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
+Object {
+  "args": Array [
+    "a",
+    "cb",
+    "restArgs",
+  ],
+  "body": "return a * 3",
+  "defaults": Object {
+    "a": "{foo: \\"ba)r\\", baz: 123}",
+    "cb": undefined,
+    "restArgs": undefined,
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": true,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a, cb, restArgs",
+  "value": "(function * namedFn (a = {foo: \\"ba)r\\", baz: 123}, cb, ...restArgs) {return a * 3})",
+}
+`;
+
 exports[`#297 - acorn loose - function * namedFn(a = (true, null)) {} 1`] = `
 Object {
   "args": Array [
@@ -6481,6 +11939,32 @@ Object {
   "name": "namedFn",
   "params": "a",
   "value": "(function * namedFn(a = (true, null)) {})",
+}
+`;
+
+exports[`#298 - acorn loose - function * namedFn (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
+Object {
+  "args": Array [
+    "b",
+    "callback",
+    "restArgs",
+  ],
+  "body": "callback(null, b + 3)",
+  "defaults": Object {
+    "b": undefined,
+    "callback": undefined,
+    "restArgs": undefined,
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": true,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "b, callback, restArgs",
+  "value": "(function * namedFn (b, callback, ...restArgs) {callback(null, b + 3)})",
 }
 `;
 
@@ -6506,6 +11990,28 @@ Object {
 }
 `;
 
+exports[`#299 - acorn loose - function * namedFn (c) {return c * 3} 1`] = `
+Object {
+  "args": Array [
+    "c",
+  ],
+  "body": "return c * 3",
+  "defaults": Object {
+    "c": undefined,
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": true,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "c",
+  "value": "(function * namedFn (c) {return c * 3})",
+}
+`;
+
 exports[`#299 - acorn loose - function * namedFn(a, b = (i++, true)) {} 1`] = `
 Object {
   "args": Array [
@@ -6527,6 +12033,28 @@ Object {
   "name": "namedFn",
   "params": "a, b",
   "value": "(function * namedFn(a, b = (i++, true)) {})",
+}
+`;
+
+exports[`#300 - acorn loose - function * namedFn (...restArgs) {return 321} 1`] = `
+Object {
+  "args": Array [
+    "restArgs",
+  ],
+  "body": "return 321",
+  "defaults": Object {
+    "restArgs": undefined,
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": true,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "restArgs",
+  "value": "(function * namedFn (...restArgs) {return 321})",
 }
 `;
 
@@ -6578,6 +12106,24 @@ Object {
 }
 `;
 
+exports[`#301 - acorn loose - function * namedFn () {} 1`] = `
+Object {
+  "args": Array [],
+  "body": "",
+  "defaults": Object {},
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": true,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "",
+  "value": "(function * namedFn () {})",
+}
+`;
+
 exports[`#302 - acorn loose - (b, callback, ...restArgs) => {callback(null, b + 3)} 1`] = `
 Object {
   "args": Array [
@@ -6604,6 +12150,28 @@ Object {
 }
 `;
 
+exports[`#302 - acorn loose - function * namedFn(a = (true, false)) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "false",
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": true,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a",
+  "value": "(function * namedFn(a = (true, false)) {})",
+}
+`;
+
 exports[`#303 - acorn loose - (c) => {return c * 3} 1`] = `
 Object {
   "args": Array [
@@ -6623,6 +12191,28 @@ Object {
   "name": null,
   "params": "c",
   "value": "((c) => {return c * 3})",
+}
+`;
+
+exports[`#303 - acorn loose - function * namedFn(a = (true, null)) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "null",
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": true,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a",
+  "value": "(function * namedFn(a = (true, null)) {})",
 }
 `;
 
@@ -6648,6 +12238,28 @@ Object {
 }
 `;
 
+exports[`#304 - acorn loose - function * namedFn(a = (true, "bar")) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "\\"bar\\"",
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": true,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a",
+  "value": "(function * namedFn(a = (true, \\"bar\\")) {})",
+}
+`;
+
 exports[`#305 - acorn loose - () => {} 1`] = `
 Object {
   "args": Array [],
@@ -6663,6 +12275,30 @@ Object {
   "name": null,
   "params": "",
   "value": "(() => {})",
+}
+`;
+
+exports[`#305 - acorn loose - function * namedFn(a, b = (i++, true)) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+    "b",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": undefined,
+    "b": "true",
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": true,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a, b",
+  "value": "(function * namedFn(a, b = (i++, true)) {})",
 }
 `;
 
@@ -6688,6 +12324,28 @@ Object {
 }
 `;
 
+exports[`#306 - acorn loose - function * namedFn(a = 1) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "1",
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": true,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a",
+  "value": "(function * namedFn(a = 1) {})",
+}
+`;
+
 exports[`#307 - acorn loose - (a = (true, null)) => {} 1`] = `
 Object {
   "args": Array [
@@ -6710,6 +12368,32 @@ Object {
 }
 `;
 
+exports[`#307 - acorn loose - (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) => {return a * 3} 1`] = `
+Object {
+  "args": Array [
+    "a",
+    "cb",
+    "restArgs",
+  ],
+  "body": "return a * 3",
+  "defaults": Object {
+    "a": "{foo: \\"ba)r\\", baz: 123}",
+    "cb": undefined,
+    "restArgs": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a, cb, restArgs",
+  "value": "((a = {foo: \\"ba)r\\", baz: 123}, cb, ...restArgs) => {return a * 3})",
+}
+`;
+
 exports[`#308 - acorn loose - (a = (true, "bar")) => {} 1`] = `
 Object {
   "args": Array [
@@ -6729,6 +12413,32 @@ Object {
   "name": null,
   "params": "a",
   "value": "((a = (true, \\"bar\\")) => {})",
+}
+`;
+
+exports[`#308 - acorn loose - (b, callback, ...restArgs) => {callback(null, b + 3)} 1`] = `
+Object {
+  "args": Array [
+    "b",
+    "callback",
+    "restArgs",
+  ],
+  "body": "callback(null, b + 3)",
+  "defaults": Object {
+    "b": undefined,
+    "callback": undefined,
+    "restArgs": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "b, callback, restArgs",
+  "value": "((b, callback, ...restArgs) => {callback(null, b + 3)})",
 }
 `;
 
@@ -6756,6 +12466,50 @@ Object {
 }
 `;
 
+exports[`#309 - acorn loose - (c) => {return c * 3} 1`] = `
+Object {
+  "args": Array [
+    "c",
+  ],
+  "body": "return c * 3",
+  "defaults": Object {
+    "c": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "c",
+  "value": "((c) => {return c * 3})",
+}
+`;
+
+exports[`#310 - acorn loose - (...restArgs) => {return 321} 1`] = `
+Object {
+  "args": Array [
+    "restArgs",
+  ],
+  "body": "return 321",
+  "defaults": Object {
+    "restArgs": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "restArgs",
+  "value": "((...restArgs) => {return 321})",
+}
+`;
+
 exports[`#310 - acorn loose - (a = 1) => {} 1`] = `
 Object {
   "args": Array [
@@ -6775,6 +12529,24 @@ Object {
   "name": null,
   "params": "a",
   "value": "((a = 1) => {})",
+}
+`;
+
+exports[`#311 - acorn loose - () => {} 1`] = `
+Object {
+  "args": Array [],
+  "body": "",
+  "defaults": Object {},
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "",
+  "value": "(() => {})",
 }
 `;
 
@@ -6800,6 +12572,28 @@ Object {
 }
 `;
 
+exports[`#312 - acorn loose - (a = (true, false)) => {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "false",
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "((a = (true, false)) => {})",
+}
+`;
+
 exports[`#312 - acorn loose - d => d * 355 * d 1`] = `
 Object {
   "args": Array [
@@ -6819,6 +12613,28 @@ Object {
   "name": null,
   "params": "d",
   "value": "(d => d * 355 * d)",
+}
+`;
+
+exports[`#313 - acorn loose - (a = (true, null)) => {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "null",
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "((a = (true, null)) => {})",
 }
 `;
 
@@ -6844,6 +12660,28 @@ Object {
 }
 `;
 
+exports[`#314 - acorn loose - (a = (true, "bar")) => {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "\\"bar\\"",
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "((a = (true, \\"bar\\")) => {})",
+}
+`;
+
 exports[`#314 - acorn loose - (a, b) => a + 3 + b 1`] = `
 Object {
   "args": Array [
@@ -6865,6 +12703,30 @@ Object {
   "name": null,
   "params": "a, b",
   "value": "((a, b) => a + 3 + b)",
+}
+`;
+
+exports[`#315 - acorn loose - (a, b = (i++, true)) => {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+    "b",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": undefined,
+    "b": "true",
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a, b",
+  "value": "((a, b = (i++, true)) => {})",
 }
 `;
 
@@ -6894,6 +12756,28 @@ Object {
 }
 `;
 
+exports[`#316 - acorn loose - (a = 1) => {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "1",
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "((a = 1) => {})",
+}
+`;
+
 exports[`#316 - acorn loose - async function (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
 Object {
   "args": Array [
@@ -6917,6 +12801,28 @@ Object {
   "name": null,
   "params": "a, cb, restArgs",
   "value": "(async function (a = {foo: \\"ba)r\\", baz: 123}, cb, ...restArgs) {return a * 3})",
+}
+`;
+
+exports[`#317 - acorn loose - (a) => a * 3 * a 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "a * 3 * a",
+  "defaults": Object {
+    "a": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": false,
+  "isExpression": true,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "((a) => a * 3 * a)",
 }
 `;
 
@@ -6968,6 +12874,28 @@ Object {
 }
 `;
 
+exports[`#318 - acorn loose - d => d * 355 * d 1`] = `
+Object {
+  "args": Array [
+    "d",
+  ],
+  "body": "d * 355 * d",
+  "defaults": Object {
+    "d": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": false,
+  "isExpression": true,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "d",
+  "value": "(d => d * 355 * d)",
+}
+`;
+
 exports[`#319 - acorn loose - async function (...restArgs) {return 321} 1`] = `
 Object {
   "args": Array [
@@ -6990,6 +12918,52 @@ Object {
 }
 `;
 
+exports[`#319 - acorn loose - e => {return e + 5235 / e} 1`] = `
+Object {
+  "args": Array [
+    "e",
+  ],
+  "body": "return e + 5235 / e",
+  "defaults": Object {
+    "e": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "e",
+  "value": "(e => {return e + 5235 / e})",
+}
+`;
+
+exports[`#320 - acorn loose - (a, b) => a + 3 + b 1`] = `
+Object {
+  "args": Array [
+    "a",
+    "b",
+  ],
+  "body": "a + 3 + b",
+  "defaults": Object {
+    "a": undefined,
+    "b": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": false,
+  "isExpression": true,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a, b",
+  "value": "((a, b) => a + 3 + b)",
+}
+`;
+
 exports[`#320 - acorn loose - async function () {} 1`] = `
 Object {
   "args": Array [],
@@ -7005,6 +12979,32 @@ Object {
   "name": null,
   "params": "",
   "value": "(async function () {})",
+}
+`;
+
+exports[`#321 - acorn loose - (x, y, ...restArgs) => console.log({ value: x * y }) 1`] = `
+Object {
+  "args": Array [
+    "x",
+    "y",
+    "restArgs",
+  ],
+  "body": "console.log({ value: x * y })",
+  "defaults": Object {
+    "restArgs": undefined,
+    "x": undefined,
+    "y": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": false,
+  "isExpression": true,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "x, y, restArgs",
+  "value": "((x, y, ...restArgs) => console.log({ value: x * y }))",
 }
 `;
 
@@ -7027,6 +13027,27 @@ Object {
   "name": null,
   "params": "a",
   "value": "(async function (a = (true, false)) {})",
+}
+`;
+
+exports[`#322 - acorn loose - ({x, y}) => {} 1`] = `
+Object {
+  "args": Array [
+    "x",
+    "y",
+  ],
+  "body": "",
+  "defaults": Object {},
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "x, y",
+  "value": "(({x, y}) => {})",
 }
 `;
 
@@ -7074,6 +13095,32 @@ Object {
 }
 `;
 
+exports[`#323 - acorn loose - async function (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
+Object {
+  "args": Array [
+    "a",
+    "cb",
+    "restArgs",
+  ],
+  "body": "return a * 3",
+  "defaults": Object {
+    "a": "{foo: \\"ba)r\\", baz: 123}",
+    "cb": undefined,
+    "restArgs": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a, cb, restArgs",
+  "value": "(async function (a = {foo: \\"ba)r\\", baz: 123}, cb, ...restArgs) {return a * 3})",
+}
+`;
+
 exports[`#324 - acorn loose - async function (a, b = (i++, true)) {} 1`] = `
 Object {
   "args": Array [
@@ -7098,6 +13145,32 @@ Object {
 }
 `;
 
+exports[`#324 - acorn loose - async function (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
+Object {
+  "args": Array [
+    "b",
+    "callback",
+    "restArgs",
+  ],
+  "body": "callback(null, b + 3)",
+  "defaults": Object {
+    "b": undefined,
+    "callback": undefined,
+    "restArgs": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "b, callback, restArgs",
+  "value": "(async function (b, callback, ...restArgs) {callback(null, b + 3)})",
+}
+`;
+
 exports[`#325 - acorn loose - async function (a = 1) {} 1`] = `
 Object {
   "args": Array [
@@ -7117,6 +13190,50 @@ Object {
   "name": null,
   "params": "a",
   "value": "(async function (a = 1) {})",
+}
+`;
+
+exports[`#325 - acorn loose - async function (c) {return c * 3} 1`] = `
+Object {
+  "args": Array [
+    "c",
+  ],
+  "body": "return c * 3",
+  "defaults": Object {
+    "c": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "c",
+  "value": "(async function (c) {return c * 3})",
+}
+`;
+
+exports[`#326 - acorn loose - async function (...restArgs) {return 321} 1`] = `
+Object {
+  "args": Array [
+    "restArgs",
+  ],
+  "body": "return 321",
+  "defaults": Object {
+    "restArgs": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "restArgs",
+  "value": "(async function (...restArgs) {return 321})",
 }
 `;
 
@@ -7146,6 +13263,24 @@ Object {
 }
 `;
 
+exports[`#327 - acorn loose - async function () {} 1`] = `
+Object {
+  "args": Array [],
+  "body": "",
+  "defaults": Object {},
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "",
+  "value": "(async function () {})",
+}
+`;
+
 exports[`#327 - acorn loose - async function namedFn (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
 Object {
   "args": Array [
@@ -7172,6 +13307,28 @@ Object {
 }
 `;
 
+exports[`#328 - acorn loose - async function (a = (true, false)) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "false",
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "(async function (a = (true, false)) {})",
+}
+`;
+
 exports[`#328 - acorn loose - async function namedFn (c) {return c * 3} 1`] = `
 Object {
   "args": Array [
@@ -7191,6 +13348,28 @@ Object {
   "name": "namedFn",
   "params": "c",
   "value": "(async function namedFn (c) {return c * 3})",
+}
+`;
+
+exports[`#329 - acorn loose - async function (a = (true, null)) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "null",
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "(async function (a = (true, null)) {})",
 }
 `;
 
@@ -7216,6 +13395,28 @@ Object {
 }
 `;
 
+exports[`#330 - acorn loose - async function (a = (true, "bar")) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "\\"bar\\"",
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "(async function (a = (true, \\"bar\\")) {})",
+}
+`;
+
 exports[`#330 - acorn loose - async function namedFn () {} 1`] = `
 Object {
   "args": Array [],
@@ -7231,6 +13432,30 @@ Object {
   "name": "namedFn",
   "params": "",
   "value": "(async function namedFn () {})",
+}
+`;
+
+exports[`#331 - acorn loose - async function (a, b = (i++, true)) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+    "b",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": undefined,
+    "b": "true",
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a, b",
+  "value": "(async function (a, b = (i++, true)) {})",
 }
 `;
 
@@ -7256,6 +13481,28 @@ Object {
 }
 `;
 
+exports[`#332 - acorn loose - async function (a = 1) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "1",
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "(async function (a = 1) {})",
+}
+`;
+
 exports[`#332 - acorn loose - async function namedFn(a = (true, null)) {} 1`] = `
 Object {
   "args": Array [
@@ -7275,6 +13522,32 @@ Object {
   "name": "namedFn",
   "params": "a",
   "value": "(async function namedFn(a = (true, null)) {})",
+}
+`;
+
+exports[`#333 - acorn loose - async function namedFn (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
+Object {
+  "args": Array [
+    "a",
+    "cb",
+    "restArgs",
+  ],
+  "body": "return a * 3",
+  "defaults": Object {
+    "a": "{foo: \\"ba)r\\", baz: 123}",
+    "cb": undefined,
+    "restArgs": undefined,
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a, cb, restArgs",
+  "value": "(async function namedFn (a = {foo: \\"ba)r\\", baz: 123}, cb, ...restArgs) {return a * 3})",
 }
 `;
 
@@ -7300,6 +13573,32 @@ Object {
 }
 `;
 
+exports[`#334 - acorn loose - async function namedFn (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
+Object {
+  "args": Array [
+    "b",
+    "callback",
+    "restArgs",
+  ],
+  "body": "callback(null, b + 3)",
+  "defaults": Object {
+    "b": undefined,
+    "callback": undefined,
+    "restArgs": undefined,
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "b, callback, restArgs",
+  "value": "(async function namedFn (b, callback, ...restArgs) {callback(null, b + 3)})",
+}
+`;
+
 exports[`#334 - acorn loose - async function namedFn(a, b = (i++, true)) {} 1`] = `
 Object {
   "args": Array [
@@ -7321,6 +13620,28 @@ Object {
   "name": "namedFn",
   "params": "a, b",
   "value": "(async function namedFn(a, b = (i++, true)) {})",
+}
+`;
+
+exports[`#335 - acorn loose - async function namedFn (c) {return c * 3} 1`] = `
+Object {
+  "args": Array [
+    "c",
+  ],
+  "body": "return c * 3",
+  "defaults": Object {
+    "c": undefined,
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "c",
+  "value": "(async function namedFn (c) {return c * 3})",
 }
 `;
 
@@ -7372,6 +13693,28 @@ Object {
 }
 `;
 
+exports[`#336 - acorn loose - async function namedFn (...restArgs) {return 321} 1`] = `
+Object {
+  "args": Array [
+    "restArgs",
+  ],
+  "body": "return 321",
+  "defaults": Object {
+    "restArgs": undefined,
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "restArgs",
+  "value": "(async function namedFn (...restArgs) {return 321})",
+}
+`;
+
 exports[`#337 - acorn loose - async (b, callback, ...restArgs) => {callback(null, b + 3)} 1`] = `
 Object {
   "args": Array [
@@ -7398,6 +13741,24 @@ Object {
 }
 `;
 
+exports[`#337 - acorn loose - async function namedFn () {} 1`] = `
+Object {
+  "args": Array [],
+  "body": "",
+  "defaults": Object {},
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "",
+  "value": "(async function namedFn () {})",
+}
+`;
+
 exports[`#338 - acorn loose - async (c) => {return c * 3} 1`] = `
 Object {
   "args": Array [
@@ -7417,6 +13778,28 @@ Object {
   "name": null,
   "params": "c",
   "value": "(async (c) => {return c * 3})",
+}
+`;
+
+exports[`#338 - acorn loose - async function namedFn(a = (true, false)) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "false",
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a",
+  "value": "(async function namedFn(a = (true, false)) {})",
 }
 `;
 
@@ -7442,6 +13825,28 @@ Object {
 }
 `;
 
+exports[`#339 - acorn loose - async function namedFn(a = (true, null)) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "null",
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a",
+  "value": "(async function namedFn(a = (true, null)) {})",
+}
+`;
+
 exports[`#340 - acorn loose - async () => {} 1`] = `
 Object {
   "args": Array [],
@@ -7457,6 +13862,28 @@ Object {
   "name": null,
   "params": "",
   "value": "(async () => {})",
+}
+`;
+
+exports[`#340 - acorn loose - async function namedFn(a = (true, "bar")) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "\\"bar\\"",
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a",
+  "value": "(async function namedFn(a = (true, \\"bar\\")) {})",
 }
 `;
 
@@ -7482,6 +13909,30 @@ Object {
 }
 `;
 
+exports[`#341 - acorn loose - async function namedFn(a, b = (i++, true)) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+    "b",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": undefined,
+    "b": "true",
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a, b",
+  "value": "(async function namedFn(a, b = (i++, true)) {})",
+}
+`;
+
 exports[`#342 - acorn loose - async (a = (true, null)) => {} 1`] = `
 Object {
   "args": Array [
@@ -7504,6 +13955,28 @@ Object {
 }
 `;
 
+exports[`#342 - acorn loose - async function namedFn(a = 1) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "1",
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a",
+  "value": "(async function namedFn(a = 1) {})",
+}
+`;
+
 exports[`#343 - acorn loose - async (a = (true, "bar")) => {} 1`] = `
 Object {
   "args": Array [
@@ -7523,6 +13996,32 @@ Object {
   "name": null,
   "params": "a",
   "value": "(async (a = (true, \\"bar\\")) => {})",
+}
+`;
+
+exports[`#343 - acorn loose - async (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) => {return a * 3} 1`] = `
+Object {
+  "args": Array [
+    "a",
+    "cb",
+    "restArgs",
+  ],
+  "body": "return a * 3",
+  "defaults": Object {
+    "a": "{foo: \\"ba)r\\", baz: 123}",
+    "cb": undefined,
+    "restArgs": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a, cb, restArgs",
+  "value": "(async (a = {foo: \\"ba)r\\", baz: 123}, cb, ...restArgs) => {return a * 3})",
 }
 `;
 
@@ -7550,6 +14049,32 @@ Object {
 }
 `;
 
+exports[`#344 - acorn loose - async (b, callback, ...restArgs) => {callback(null, b + 3)} 1`] = `
+Object {
+  "args": Array [
+    "b",
+    "callback",
+    "restArgs",
+  ],
+  "body": "callback(null, b + 3)",
+  "defaults": Object {
+    "b": undefined,
+    "callback": undefined,
+    "restArgs": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "b, callback, restArgs",
+  "value": "(async (b, callback, ...restArgs) => {callback(null, b + 3)})",
+}
+`;
+
 exports[`#345 - acorn loose - async (a = 1) => {} 1`] = `
 Object {
   "args": Array [
@@ -7569,6 +14094,50 @@ Object {
   "name": null,
   "params": "a",
   "value": "(async (a = 1) => {})",
+}
+`;
+
+exports[`#345 - acorn loose - async (c) => {return c * 3} 1`] = `
+Object {
+  "args": Array [
+    "c",
+  ],
+  "body": "return c * 3",
+  "defaults": Object {
+    "c": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "c",
+  "value": "(async (c) => {return c * 3})",
+}
+`;
+
+exports[`#346 - acorn loose - async (...restArgs) => {return 321} 1`] = `
+Object {
+  "args": Array [
+    "restArgs",
+  ],
+  "body": "return 321",
+  "defaults": Object {
+    "restArgs": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "restArgs",
+  "value": "(async (...restArgs) => {return 321})",
 }
 `;
 
@@ -7594,6 +14163,24 @@ Object {
 }
 `;
 
+exports[`#347 - acorn loose - async () => {} 1`] = `
+Object {
+  "args": Array [],
+  "body": "",
+  "defaults": Object {},
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "",
+  "value": "(async () => {})",
+}
+`;
+
 exports[`#347 - acorn loose - async d => d * 355 * d 1`] = `
 Object {
   "args": Array [
@@ -7613,6 +14200,28 @@ Object {
   "name": null,
   "params": "d",
   "value": "(async d => d * 355 * d)",
+}
+`;
+
+exports[`#348 - acorn loose - async (a = (true, false)) => {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "false",
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "(async (a = (true, false)) => {})",
 }
 `;
 
@@ -7638,6 +14247,28 @@ Object {
 }
 `;
 
+exports[`#349 - acorn loose - async (a = (true, null)) => {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "null",
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "(async (a = (true, null)) => {})",
+}
+`;
+
 exports[`#349 - acorn loose - async (a, b) => a + 3 + b 1`] = `
 Object {
   "args": Array [
@@ -7659,6 +14290,28 @@ Object {
   "name": null,
   "params": "a, b",
   "value": "(async (a, b) => a + 3 + b)",
+}
+`;
+
+exports[`#350 - acorn loose - async (a = (true, "bar")) => {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "\\"bar\\"",
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "(async (a = (true, \\"bar\\")) => {})",
 }
 `;
 
@@ -7688,6 +14341,30 @@ Object {
 }
 `;
 
+exports[`#351 - acorn loose - async (a, b = (i++, true)) => {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+    "b",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": undefined,
+    "b": "true",
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a, b",
+  "value": "(async (a, b = (i++, true)) => {})",
+}
+`;
+
 exports[`#351 - acorn loose - should return object with default values when invalid 1`] = `
 Object {
   "args": Array [],
@@ -7706,6 +14383,28 @@ Object {
 }
 `;
 
+exports[`#352 - acorn loose - async (a = 1) => {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "1",
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "(async (a = 1) => {})",
+}
+`;
+
 exports[`#352 - acorn loose - should have '.isValid' and few '.is*'' hidden properties 1`] = `
 Object {
   "args": Array [],
@@ -7721,6 +14420,122 @@ Object {
   "name": null,
   "params": "",
   "value": "",
+}
+`;
+
+exports[`#353 - acorn loose - async (a) => a * 3 * a 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "a * 3 * a",
+  "defaults": Object {
+    "a": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": true,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "(async (a) => a * 3 * a)",
+}
+`;
+
+exports[`#354 - acorn loose - async d => d * 355 * d 1`] = `
+Object {
+  "args": Array [
+    "d",
+  ],
+  "body": "d * 355 * d",
+  "defaults": Object {
+    "d": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": true,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "d",
+  "value": "(async d => d * 355 * d)",
+}
+`;
+
+exports[`#355 - acorn loose - async e => {return e + 5235 / e} 1`] = `
+Object {
+  "args": Array [
+    "e",
+  ],
+  "body": "return e + 5235 / e",
+  "defaults": Object {
+    "e": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "e",
+  "value": "(async e => {return e + 5235 / e})",
+}
+`;
+
+exports[`#356 - acorn loose - async (a, b) => a + 3 + b 1`] = `
+Object {
+  "args": Array [
+    "a",
+    "b",
+  ],
+  "body": "a + 3 + b",
+  "defaults": Object {
+    "a": undefined,
+    "b": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": true,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a, b",
+  "value": "(async (a, b) => a + 3 + b)",
+}
+`;
+
+exports[`#357 - acorn loose - async (x, y, ...restArgs) => console.log({ value: x * y }) 1`] = `
+Object {
+  "args": Array [
+    "x",
+    "y",
+    "restArgs",
+  ],
+  "body": "console.log({ value: x * y })",
+  "defaults": Object {
+    "restArgs": undefined,
+    "x": undefined,
+    "y": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": true,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "x, y, restArgs",
+  "value": "(async (x, y, ...restArgs) => console.log({ value: x * y }))",
 }
 `;
 
@@ -7832,6 +14647,63 @@ Object {
 }
 `;
 
+exports[`#358 - acorn loose - async ({x, y}) => {} 1`] = `
+Object {
+  "args": Array [
+    "x",
+    "y",
+  ],
+  "body": "",
+  "defaults": Object {},
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "x, y",
+  "value": "(async ({x, y}) => {})",
+}
+`;
+
+exports[`#359 - acorn loose - should return object with default values when invalid 1`] = `
+Object {
+  "args": Array [],
+  "body": "",
+  "defaults": Object {},
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": false,
+  "name": null,
+  "params": "",
+  "value": "",
+}
+`;
+
+exports[`#360 - acorn loose - should have '.isValid' and few '.is*'' hidden properties 1`] = `
+Object {
+  "args": Array [],
+  "body": "",
+  "defaults": Object {},
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": false,
+  "name": null,
+  "params": "",
+  "value": "",
+}
+`;
+
 exports[`#361 - espree.parse - function (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
 Object {
   "args": Array [
@@ -7928,6 +14800,114 @@ Object {
 }
 `;
 
+exports[`#365 - acorn loose - should work for object methods 1`] = `
+Object {
+  "args": Array [
+    "a",
+    "b",
+    "c",
+  ],
+  "body": "
+        return 123;
+      ",
+  "defaults": Object {
+    "a": undefined,
+    "b": undefined,
+    "c": undefined,
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "foo",
+  "params": "a, b, c",
+  "value": "({ foo(a, b, c) {
+        return 123;
+      } })",
+}
+`;
+
+exports[`#365 - acorn loose - should work for object methods 2`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "
+        return () => a;
+      ",
+  "defaults": Object {
+    "a": undefined,
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "bar",
+  "params": "a",
+  "value": "({ bar(a) {
+        return () => a;
+      } })",
+}
+`;
+
+exports[`#365 - acorn loose - should work for object methods 3`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "
+        return yield a * 321;
+      ",
+  "defaults": Object {
+    "a": undefined,
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": true,
+  "isNamed": true,
+  "isValid": true,
+  "name": "gen",
+  "params": "a",
+  "value": "({ *gen(a) {
+        return yield a * 321;
+      } })",
+}
+`;
+
+exports[`#365 - acorn loose - should work for object methods 4`] = `
+Object {
+  "args": Array [
+    "a",
+    "cb",
+    "restArgs",
+  ],
+  "body": " return a * 3 ",
+  "defaults": Object {
+    "a": "{foo: 'ba)r', baz: 123}",
+    "cb": undefined,
+    "restArgs": undefined,
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a, cb, restArgs",
+  "value": "({ namedFn (a = {foo: 'ba)r', baz: 123}, cb, ...restArgs) { return a * 3 } })",
+}
+`;
+
 exports[`#365 - espree.parse - function () {} 1`] = `
 Object {
   "args": Array [],
@@ -8012,6 +14992,32 @@ Object {
 }
 `;
 
+exports[`#369 - espree.parse - function (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
+Object {
+  "args": Array [
+    "a",
+    "cb",
+    "restArgs",
+  ],
+  "body": "return a * 3",
+  "defaults": Object {
+    "a": "{foo: \\"ba)r\\", baz: 123}",
+    "cb": undefined,
+    "restArgs": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a, cb, restArgs",
+  "value": "(function (a = {foo: \\"ba)r\\", baz: 123}, cb, ...restArgs) {return a * 3})",
+}
+`;
+
 exports[`#369 - espree.parse - function (a, b = (i++, true)) {} 1`] = `
 Object {
   "args": Array [
@@ -8058,6 +15064,54 @@ Object {
 }
 `;
 
+exports[`#370 - espree.parse - function (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
+Object {
+  "args": Array [
+    "b",
+    "callback",
+    "restArgs",
+  ],
+  "body": "callback(null, b + 3)",
+  "defaults": Object {
+    "b": undefined,
+    "callback": undefined,
+    "restArgs": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "b, callback, restArgs",
+  "value": "(function (b, callback, ...restArgs) {callback(null, b + 3)})",
+}
+`;
+
+exports[`#371 - espree.parse - function (c) {return c * 3} 1`] = `
+Object {
+  "args": Array [
+    "c",
+  ],
+  "body": "return c * 3",
+  "defaults": Object {
+    "c": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "c",
+  "value": "(function (c) {return c * 3})",
+}
+`;
+
 exports[`#371 - espree.parse - function namedFn (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
 Object {
   "args": Array [
@@ -8081,6 +15135,28 @@ Object {
   "name": "namedFn",
   "params": "a, cb, restArgs",
   "value": "(function namedFn (a = {foo: \\"ba)r\\", baz: 123}, cb, ...restArgs) {return a * 3})",
+}
+`;
+
+exports[`#372 - espree.parse - function (...restArgs) {return 321} 1`] = `
+Object {
+  "args": Array [
+    "restArgs",
+  ],
+  "body": "return 321",
+  "defaults": Object {
+    "restArgs": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "restArgs",
+  "value": "(function (...restArgs) {return 321})",
 }
 `;
 
@@ -8110,6 +15186,24 @@ Object {
 }
 `;
 
+exports[`#373 - espree.parse - function () {} 1`] = `
+Object {
+  "args": Array [],
+  "body": "",
+  "defaults": Object {},
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "",
+  "value": "(function () {})",
+}
+`;
+
 exports[`#373 - espree.parse - function namedFn (c) {return c * 3} 1`] = `
 Object {
   "args": Array [
@@ -8129,6 +15223,28 @@ Object {
   "name": "namedFn",
   "params": "c",
   "value": "(function namedFn (c) {return c * 3})",
+}
+`;
+
+exports[`#374 - espree.parse - function (a = (true, false)) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "false",
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "(function (a = (true, false)) {})",
 }
 `;
 
@@ -8154,6 +15270,28 @@ Object {
 }
 `;
 
+exports[`#375 - espree.parse - function (a = (true, null)) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "null",
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "(function (a = (true, null)) {})",
+}
+`;
+
 exports[`#375 - espree.parse - function namedFn () {} 1`] = `
 Object {
   "args": Array [],
@@ -8169,6 +15307,28 @@ Object {
   "name": "namedFn",
   "params": "",
   "value": "(function namedFn () {})",
+}
+`;
+
+exports[`#376 - espree.parse - function (a = (true, "bar")) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "\\"bar\\"",
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "(function (a = (true, \\"bar\\")) {})",
 }
 `;
 
@@ -8194,6 +15354,30 @@ Object {
 }
 `;
 
+exports[`#377 - espree.parse - function (a, b = (i++, true)) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+    "b",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": undefined,
+    "b": "true",
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a, b",
+  "value": "(function (a, b = (i++, true)) {})",
+}
+`;
+
 exports[`#377 - espree.parse - function namedFn(a = (true, null)) {} 1`] = `
 Object {
   "args": Array [
@@ -8213,6 +15397,28 @@ Object {
   "name": "namedFn",
   "params": "a",
   "value": "(function namedFn(a = (true, null)) {})",
+}
+`;
+
+exports[`#378 - espree.parse - function (a = 1) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "1",
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "(function (a = 1) {})",
 }
 `;
 
@@ -8238,6 +15444,32 @@ Object {
 }
 `;
 
+exports[`#379 - espree.parse - function namedFn (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
+Object {
+  "args": Array [
+    "a",
+    "cb",
+    "restArgs",
+  ],
+  "body": "return a * 3",
+  "defaults": Object {
+    "a": "{foo: \\"ba)r\\", baz: 123}",
+    "cb": undefined,
+    "restArgs": undefined,
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a, cb, restArgs",
+  "value": "(function namedFn (a = {foo: \\"ba)r\\", baz: 123}, cb, ...restArgs) {return a * 3})",
+}
+`;
+
 exports[`#379 - espree.parse - function namedFn(a, b = (i++, true)) {} 1`] = `
 Object {
   "args": Array [
@@ -8259,6 +15491,32 @@ Object {
   "name": "namedFn",
   "params": "a, b",
   "value": "(function namedFn(a, b = (i++, true)) {})",
+}
+`;
+
+exports[`#380 - espree.parse - function namedFn (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
+Object {
+  "args": Array [
+    "b",
+    "callback",
+    "restArgs",
+  ],
+  "body": "callback(null, b + 3)",
+  "defaults": Object {
+    "b": undefined,
+    "callback": undefined,
+    "restArgs": undefined,
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "b, callback, restArgs",
+  "value": "(function namedFn (b, callback, ...restArgs) {callback(null, b + 3)})",
 }
 `;
 
@@ -8310,6 +15568,28 @@ Object {
 }
 `;
 
+exports[`#381 - espree.parse - function namedFn (c) {return c * 3} 1`] = `
+Object {
+  "args": Array [
+    "c",
+  ],
+  "body": "return c * 3",
+  "defaults": Object {
+    "c": undefined,
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "c",
+  "value": "(function namedFn (c) {return c * 3})",
+}
+`;
+
 exports[`#382 - espree.parse - function * namedFn (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
 Object {
   "args": Array [
@@ -8336,6 +15616,28 @@ Object {
 }
 `;
 
+exports[`#382 - espree.parse - function namedFn (...restArgs) {return 321} 1`] = `
+Object {
+  "args": Array [
+    "restArgs",
+  ],
+  "body": "return 321",
+  "defaults": Object {
+    "restArgs": undefined,
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "restArgs",
+  "value": "(function namedFn (...restArgs) {return 321})",
+}
+`;
+
 exports[`#383 - espree.parse - function * namedFn (c) {return c * 3} 1`] = `
 Object {
   "args": Array [
@@ -8355,6 +15657,24 @@ Object {
   "name": "namedFn",
   "params": "c",
   "value": "(function * namedFn (c) {return c * 3})",
+}
+`;
+
+exports[`#383 - espree.parse - function namedFn () {} 1`] = `
+Object {
+  "args": Array [],
+  "body": "",
+  "defaults": Object {},
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "",
+  "value": "(function namedFn () {})",
 }
 `;
 
@@ -8380,6 +15700,28 @@ Object {
 }
 `;
 
+exports[`#384 - espree.parse - function namedFn(a = (true, false)) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "false",
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a",
+  "value": "(function namedFn(a = (true, false)) {})",
+}
+`;
+
 exports[`#385 - espree.parse - function * namedFn () {} 1`] = `
 Object {
   "args": Array [],
@@ -8395,6 +15737,28 @@ Object {
   "name": "namedFn",
   "params": "",
   "value": "(function * namedFn () {})",
+}
+`;
+
+exports[`#385 - espree.parse - function namedFn(a = (true, null)) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "null",
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a",
+  "value": "(function namedFn(a = (true, null)) {})",
 }
 `;
 
@@ -8420,6 +15784,28 @@ Object {
 }
 `;
 
+exports[`#386 - espree.parse - function namedFn(a = (true, "bar")) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "\\"bar\\"",
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a",
+  "value": "(function namedFn(a = (true, \\"bar\\")) {})",
+}
+`;
+
 exports[`#387 - espree.parse - function * namedFn(a = (true, null)) {} 1`] = `
 Object {
   "args": Array [
@@ -8439,6 +15825,30 @@ Object {
   "name": "namedFn",
   "params": "a",
   "value": "(function * namedFn(a = (true, null)) {})",
+}
+`;
+
+exports[`#387 - espree.parse - function namedFn(a, b = (i++, true)) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+    "b",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": undefined,
+    "b": "true",
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a, b",
+  "value": "(function namedFn(a, b = (i++, true)) {})",
 }
 `;
 
@@ -8464,6 +15874,54 @@ Object {
 }
 `;
 
+exports[`#388 - espree.parse - function namedFn(a = 1) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "1",
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a",
+  "value": "(function namedFn(a = 1) {})",
+}
+`;
+
+exports[`#389 - espree.parse - function * namedFn (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
+Object {
+  "args": Array [
+    "a",
+    "cb",
+    "restArgs",
+  ],
+  "body": "return a * 3",
+  "defaults": Object {
+    "a": "{foo: \\"ba)r\\", baz: 123}",
+    "cb": undefined,
+    "restArgs": undefined,
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": true,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a, cb, restArgs",
+  "value": "(function * namedFn (a = {foo: \\"ba)r\\", baz: 123}, cb, ...restArgs) {return a * 3})",
+}
+`;
+
 exports[`#389 - espree.parse - function * namedFn(a, b = (i++, true)) {} 1`] = `
 Object {
   "args": Array [
@@ -8485,6 +15943,32 @@ Object {
   "name": "namedFn",
   "params": "a, b",
   "value": "(function * namedFn(a, b = (i++, true)) {})",
+}
+`;
+
+exports[`#390 - espree.parse - function * namedFn (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
+Object {
+  "args": Array [
+    "b",
+    "callback",
+    "restArgs",
+  ],
+  "body": "callback(null, b + 3)",
+  "defaults": Object {
+    "b": undefined,
+    "callback": undefined,
+    "restArgs": undefined,
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": true,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "b, callback, restArgs",
+  "value": "(function * namedFn (b, callback, ...restArgs) {callback(null, b + 3)})",
 }
 `;
 
@@ -8536,6 +16020,28 @@ Object {
 }
 `;
 
+exports[`#391 - espree.parse - function * namedFn (c) {return c * 3} 1`] = `
+Object {
+  "args": Array [
+    "c",
+  ],
+  "body": "return c * 3",
+  "defaults": Object {
+    "c": undefined,
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": true,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "c",
+  "value": "(function * namedFn (c) {return c * 3})",
+}
+`;
+
 exports[`#392 - espree.parse - (b, callback, ...restArgs) => {callback(null, b + 3)} 1`] = `
 Object {
   "args": Array [
@@ -8562,6 +16068,28 @@ Object {
 }
 `;
 
+exports[`#392 - espree.parse - function * namedFn (...restArgs) {return 321} 1`] = `
+Object {
+  "args": Array [
+    "restArgs",
+  ],
+  "body": "return 321",
+  "defaults": Object {
+    "restArgs": undefined,
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": true,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "restArgs",
+  "value": "(function * namedFn (...restArgs) {return 321})",
+}
+`;
+
 exports[`#393 - espree.parse - (c) => {return c * 3} 1`] = `
 Object {
   "args": Array [
@@ -8581,6 +16109,24 @@ Object {
   "name": null,
   "params": "c",
   "value": "((c) => {return c * 3})",
+}
+`;
+
+exports[`#393 - espree.parse - function * namedFn () {} 1`] = `
+Object {
+  "args": Array [],
+  "body": "",
+  "defaults": Object {},
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": true,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "",
+  "value": "(function * namedFn () {})",
 }
 `;
 
@@ -8606,6 +16152,28 @@ Object {
 }
 `;
 
+exports[`#394 - espree.parse - function * namedFn(a = (true, false)) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "false",
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": true,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a",
+  "value": "(function * namedFn(a = (true, false)) {})",
+}
+`;
+
 exports[`#395 - espree.parse - () => {} 1`] = `
 Object {
   "args": Array [],
@@ -8621,6 +16189,28 @@ Object {
   "name": null,
   "params": "",
   "value": "(() => {})",
+}
+`;
+
+exports[`#395 - espree.parse - function * namedFn(a = (true, null)) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "null",
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": true,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a",
+  "value": "(function * namedFn(a = (true, null)) {})",
 }
 `;
 
@@ -8646,6 +16236,28 @@ Object {
 }
 `;
 
+exports[`#396 - espree.parse - function * namedFn(a = (true, "bar")) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "\\"bar\\"",
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": true,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a",
+  "value": "(function * namedFn(a = (true, \\"bar\\")) {})",
+}
+`;
+
 exports[`#397 - espree.parse - (a = (true, null)) => {} 1`] = `
 Object {
   "args": Array [
@@ -8668,6 +16280,30 @@ Object {
 }
 `;
 
+exports[`#397 - espree.parse - function * namedFn(a, b = (i++, true)) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+    "b",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": undefined,
+    "b": "true",
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": true,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a, b",
+  "value": "(function * namedFn(a, b = (i++, true)) {})",
+}
+`;
+
 exports[`#398 - espree.parse - (a = (true, "bar")) => {} 1`] = `
 Object {
   "args": Array [
@@ -8687,6 +16323,54 @@ Object {
   "name": null,
   "params": "a",
   "value": "((a = (true, \\"bar\\")) => {})",
+}
+`;
+
+exports[`#398 - espree.parse - function * namedFn(a = 1) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "1",
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": true,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a",
+  "value": "(function * namedFn(a = 1) {})",
+}
+`;
+
+exports[`#399 - espree.parse - (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) => {return a * 3} 1`] = `
+Object {
+  "args": Array [
+    "a",
+    "cb",
+    "restArgs",
+  ],
+  "body": "return a * 3",
+  "defaults": Object {
+    "a": "{foo: \\"ba)r\\", baz: 123}",
+    "cb": undefined,
+    "restArgs": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a, cb, restArgs",
+  "value": "((a = {foo: \\"ba)r\\", baz: 123}, cb, ...restArgs) => {return a * 3})",
 }
 `;
 
@@ -8736,6 +16420,32 @@ Object {
 }
 `;
 
+exports[`#400 - espree.parse - (b, callback, ...restArgs) => {callback(null, b + 3)} 1`] = `
+Object {
+  "args": Array [
+    "b",
+    "callback",
+    "restArgs",
+  ],
+  "body": "callback(null, b + 3)",
+  "defaults": Object {
+    "b": undefined,
+    "callback": undefined,
+    "restArgs": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "b, callback, restArgs",
+  "value": "((b, callback, ...restArgs) => {callback(null, b + 3)})",
+}
+`;
+
 exports[`#401 - espree.parse - (a) => a * 3 * a 1`] = `
 Object {
   "args": Array [
@@ -8755,6 +16465,50 @@ Object {
   "name": null,
   "params": "a",
   "value": "((a) => a * 3 * a)",
+}
+`;
+
+exports[`#401 - espree.parse - (c) => {return c * 3} 1`] = `
+Object {
+  "args": Array [
+    "c",
+  ],
+  "body": "return c * 3",
+  "defaults": Object {
+    "c": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "c",
+  "value": "((c) => {return c * 3})",
+}
+`;
+
+exports[`#402 - espree.parse - (...restArgs) => {return 321} 1`] = `
+Object {
+  "args": Array [
+    "restArgs",
+  ],
+  "body": "return 321",
+  "defaults": Object {
+    "restArgs": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "restArgs",
+  "value": "((...restArgs) => {return 321})",
 }
 `;
 
@@ -8780,6 +16534,24 @@ Object {
 }
 `;
 
+exports[`#403 - espree.parse - () => {} 1`] = `
+Object {
+  "args": Array [],
+  "body": "",
+  "defaults": Object {},
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "",
+  "value": "(() => {})",
+}
+`;
+
 exports[`#403 - espree.parse - e => {return e + 5235 / e} 1`] = `
 Object {
   "args": Array [
@@ -8799,6 +16571,28 @@ Object {
   "name": null,
   "params": "e",
   "value": "(e => {return e + 5235 / e})",
+}
+`;
+
+exports[`#404 - espree.parse - (a = (true, false)) => {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "false",
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "((a = (true, false)) => {})",
 }
 `;
 
@@ -8823,6 +16617,28 @@ Object {
   "name": null,
   "params": "a, b",
   "value": "((a, b) => a + 3 + b)",
+}
+`;
+
+exports[`#405 - espree.parse - (a = (true, null)) => {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "null",
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "((a = (true, null)) => {})",
 }
 `;
 
@@ -8852,6 +16668,28 @@ Object {
 }
 `;
 
+exports[`#406 - espree.parse - (a = (true, "bar")) => {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "\\"bar\\"",
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "((a = (true, \\"bar\\")) => {})",
+}
+`;
+
 exports[`#406 - espree.parse - async function (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
 Object {
   "args": Array [
@@ -8875,6 +16713,30 @@ Object {
   "name": null,
   "params": "a, cb, restArgs",
   "value": "(async function (a = {foo: \\"ba)r\\", baz: 123}, cb, ...restArgs) {return a * 3})",
+}
+`;
+
+exports[`#407 - espree.parse - (a, b = (i++, true)) => {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+    "b",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": undefined,
+    "b": "true",
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a, b",
+  "value": "((a, b = (i++, true)) => {})",
 }
 `;
 
@@ -8904,6 +16766,28 @@ Object {
 }
 `;
 
+exports[`#408 - espree.parse - (a = 1) => {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "1",
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "((a = 1) => {})",
+}
+`;
+
 exports[`#408 - espree.parse - async function (c) {return c * 3} 1`] = `
 Object {
   "args": Array [
@@ -8923,6 +16807,28 @@ Object {
   "name": null,
   "params": "c",
   "value": "(async function (c) {return c * 3})",
+}
+`;
+
+exports[`#409 - espree.parse - (a) => a * 3 * a 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "a * 3 * a",
+  "defaults": Object {
+    "a": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": false,
+  "isExpression": true,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "((a) => a * 3 * a)",
 }
 `;
 
@@ -8966,6 +16872,28 @@ Object {
 }
 `;
 
+exports[`#410 - espree.parse - d => d * 355 * d 1`] = `
+Object {
+  "args": Array [
+    "d",
+  ],
+  "body": "d * 355 * d",
+  "defaults": Object {
+    "d": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": false,
+  "isExpression": true,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "d",
+  "value": "(d => d * 355 * d)",
+}
+`;
+
 exports[`#411 - espree.parse - async function (a = (true, false)) {} 1`] = `
 Object {
   "args": Array [
@@ -8985,6 +16913,52 @@ Object {
   "name": null,
   "params": "a",
   "value": "(async function (a = (true, false)) {})",
+}
+`;
+
+exports[`#411 - espree.parse - e => {return e + 5235 / e} 1`] = `
+Object {
+  "args": Array [
+    "e",
+  ],
+  "body": "return e + 5235 / e",
+  "defaults": Object {
+    "e": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "e",
+  "value": "(e => {return e + 5235 / e})",
+}
+`;
+
+exports[`#412 - espree.parse - (a, b) => a + 3 + b 1`] = `
+Object {
+  "args": Array [
+    "a",
+    "b",
+  ],
+  "body": "a + 3 + b",
+  "defaults": Object {
+    "a": undefined,
+    "b": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": false,
+  "isExpression": true,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a, b",
+  "value": "((a, b) => a + 3 + b)",
 }
 `;
 
@@ -9010,6 +16984,32 @@ Object {
 }
 `;
 
+exports[`#413 - espree.parse - (x, y, ...restArgs) => console.log({ value: x * y }) 1`] = `
+Object {
+  "args": Array [
+    "x",
+    "y",
+    "restArgs",
+  ],
+  "body": "console.log({ value: x * y })",
+  "defaults": Object {
+    "restArgs": undefined,
+    "x": undefined,
+    "y": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": false,
+  "isExpression": true,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "x, y, restArgs",
+  "value": "((x, y, ...restArgs) => console.log({ value: x * y }))",
+}
+`;
+
 exports[`#413 - espree.parse - async function (a = (true, "bar")) {} 1`] = `
 Object {
   "args": Array [
@@ -9029,6 +17029,27 @@ Object {
   "name": null,
   "params": "a",
   "value": "(async function (a = (true, \\"bar\\")) {})",
+}
+`;
+
+exports[`#414 - espree.parse - ({x, y}) => {} 1`] = `
+Object {
+  "args": Array [
+    "x",
+    "y",
+  ],
+  "body": "",
+  "defaults": Object {},
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "x, y",
+  "value": "(({x, y}) => {})",
 }
 `;
 
@@ -9056,6 +17077,32 @@ Object {
 }
 `;
 
+exports[`#415 - espree.parse - async function (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
+Object {
+  "args": Array [
+    "a",
+    "cb",
+    "restArgs",
+  ],
+  "body": "return a * 3",
+  "defaults": Object {
+    "a": "{foo: \\"ba)r\\", baz: 123}",
+    "cb": undefined,
+    "restArgs": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a, cb, restArgs",
+  "value": "(async function (a = {foo: \\"ba)r\\", baz: 123}, cb, ...restArgs) {return a * 3})",
+}
+`;
+
 exports[`#415 - espree.parse - async function (a = 1) {} 1`] = `
 Object {
   "args": Array [
@@ -9075,6 +17122,32 @@ Object {
   "name": null,
   "params": "a",
   "value": "(async function (a = 1) {})",
+}
+`;
+
+exports[`#416 - espree.parse - async function (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
+Object {
+  "args": Array [
+    "b",
+    "callback",
+    "restArgs",
+  ],
+  "body": "callback(null, b + 3)",
+  "defaults": Object {
+    "b": undefined,
+    "callback": undefined,
+    "restArgs": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "b, callback, restArgs",
+  "value": "(async function (b, callback, ...restArgs) {callback(null, b + 3)})",
 }
 `;
 
@@ -9104,6 +17177,28 @@ Object {
 }
 `;
 
+exports[`#417 - espree.parse - async function (c) {return c * 3} 1`] = `
+Object {
+  "args": Array [
+    "c",
+  ],
+  "body": "return c * 3",
+  "defaults": Object {
+    "c": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "c",
+  "value": "(async function (c) {return c * 3})",
+}
+`;
+
 exports[`#417 - espree.parse - async function namedFn (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
 Object {
   "args": Array [
@@ -9130,6 +17225,28 @@ Object {
 }
 `;
 
+exports[`#418 - espree.parse - async function (...restArgs) {return 321} 1`] = `
+Object {
+  "args": Array [
+    "restArgs",
+  ],
+  "body": "return 321",
+  "defaults": Object {
+    "restArgs": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "restArgs",
+  "value": "(async function (...restArgs) {return 321})",
+}
+`;
+
 exports[`#418 - espree.parse - async function namedFn (c) {return c * 3} 1`] = `
 Object {
   "args": Array [
@@ -9149,6 +17266,24 @@ Object {
   "name": "namedFn",
   "params": "c",
   "value": "(async function namedFn (c) {return c * 3})",
+}
+`;
+
+exports[`#419 - espree.parse - async function () {} 1`] = `
+Object {
+  "args": Array [],
+  "body": "",
+  "defaults": Object {},
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "",
+  "value": "(async function () {})",
 }
 `;
 
@@ -9174,6 +17309,28 @@ Object {
 }
 `;
 
+exports[`#420 - espree.parse - async function (a = (true, false)) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "false",
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "(async function (a = (true, false)) {})",
+}
+`;
+
 exports[`#420 - espree.parse - async function namedFn () {} 1`] = `
 Object {
   "args": Array [],
@@ -9189,6 +17346,28 @@ Object {
   "name": "namedFn",
   "params": "",
   "value": "(async function namedFn () {})",
+}
+`;
+
+exports[`#421 - espree.parse - async function (a = (true, null)) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "null",
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "(async function (a = (true, null)) {})",
 }
 `;
 
@@ -9214,6 +17393,28 @@ Object {
 }
 `;
 
+exports[`#422 - espree.parse - async function (a = (true, "bar")) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "\\"bar\\"",
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "(async function (a = (true, \\"bar\\")) {})",
+}
+`;
+
 exports[`#422 - espree.parse - async function namedFn(a = (true, null)) {} 1`] = `
 Object {
   "args": Array [
@@ -9233,6 +17434,30 @@ Object {
   "name": "namedFn",
   "params": "a",
   "value": "(async function namedFn(a = (true, null)) {})",
+}
+`;
+
+exports[`#423 - espree.parse - async function (a, b = (i++, true)) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+    "b",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": undefined,
+    "b": "true",
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a, b",
+  "value": "(async function (a, b = (i++, true)) {})",
 }
 `;
 
@@ -9258,6 +17483,28 @@ Object {
 }
 `;
 
+exports[`#424 - espree.parse - async function (a = 1) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "1",
+  },
+  "isAnonymous": true,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "(async function (a = 1) {})",
+}
+`;
+
 exports[`#424 - espree.parse - async function namedFn(a, b = (i++, true)) {} 1`] = `
 Object {
   "args": Array [
@@ -9279,6 +17526,32 @@ Object {
   "name": "namedFn",
   "params": "a, b",
   "value": "(async function namedFn(a, b = (i++, true)) {})",
+}
+`;
+
+exports[`#425 - espree.parse - async function namedFn (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3} 1`] = `
+Object {
+  "args": Array [
+    "a",
+    "cb",
+    "restArgs",
+  ],
+  "body": "return a * 3",
+  "defaults": Object {
+    "a": "{foo: \\"ba)r\\", baz: 123}",
+    "cb": undefined,
+    "restArgs": undefined,
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a, cb, restArgs",
+  "value": "(async function namedFn (a = {foo: \\"ba)r\\", baz: 123}, cb, ...restArgs) {return a * 3})",
 }
 `;
 
@@ -9330,6 +17603,32 @@ Object {
 }
 `;
 
+exports[`#426 - espree.parse - async function namedFn (b, callback, ...restArgs) {callback(null, b + 3)} 1`] = `
+Object {
+  "args": Array [
+    "b",
+    "callback",
+    "restArgs",
+  ],
+  "body": "callback(null, b + 3)",
+  "defaults": Object {
+    "b": undefined,
+    "callback": undefined,
+    "restArgs": undefined,
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "b, callback, restArgs",
+  "value": "(async function namedFn (b, callback, ...restArgs) {callback(null, b + 3)})",
+}
+`;
+
 exports[`#427 - espree.parse - async (b, callback, ...restArgs) => {callback(null, b + 3)} 1`] = `
 Object {
   "args": Array [
@@ -9356,6 +17655,28 @@ Object {
 }
 `;
 
+exports[`#427 - espree.parse - async function namedFn (c) {return c * 3} 1`] = `
+Object {
+  "args": Array [
+    "c",
+  ],
+  "body": "return c * 3",
+  "defaults": Object {
+    "c": undefined,
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "c",
+  "value": "(async function namedFn (c) {return c * 3})",
+}
+`;
+
 exports[`#428 - espree.parse - async (c) => {return c * 3} 1`] = `
 Object {
   "args": Array [
@@ -9375,6 +17696,28 @@ Object {
   "name": null,
   "params": "c",
   "value": "(async (c) => {return c * 3})",
+}
+`;
+
+exports[`#428 - espree.parse - async function namedFn (...restArgs) {return 321} 1`] = `
+Object {
+  "args": Array [
+    "restArgs",
+  ],
+  "body": "return 321",
+  "defaults": Object {
+    "restArgs": undefined,
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "restArgs",
+  "value": "(async function namedFn (...restArgs) {return 321})",
 }
 `;
 
@@ -9400,6 +17743,24 @@ Object {
 }
 `;
 
+exports[`#429 - espree.parse - async function namedFn () {} 1`] = `
+Object {
+  "args": Array [],
+  "body": "",
+  "defaults": Object {},
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "",
+  "value": "(async function namedFn () {})",
+}
+`;
+
 exports[`#430 - espree.parse - async () => {} 1`] = `
 Object {
   "args": Array [],
@@ -9415,6 +17776,28 @@ Object {
   "name": null,
   "params": "",
   "value": "(async () => {})",
+}
+`;
+
+exports[`#430 - espree.parse - async function namedFn(a = (true, false)) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "false",
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a",
+  "value": "(async function namedFn(a = (true, false)) {})",
 }
 `;
 
@@ -9440,6 +17823,28 @@ Object {
 }
 `;
 
+exports[`#431 - espree.parse - async function namedFn(a = (true, null)) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "null",
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a",
+  "value": "(async function namedFn(a = (true, null)) {})",
+}
+`;
+
 exports[`#432 - espree.parse - async (a = (true, null)) => {} 1`] = `
 Object {
   "args": Array [
@@ -9459,6 +17864,28 @@ Object {
   "name": null,
   "params": "a",
   "value": "(async (a = (true, null)) => {})",
+}
+`;
+
+exports[`#432 - espree.parse - async function namedFn(a = (true, "bar")) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "\\"bar\\"",
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a",
+  "value": "(async function namedFn(a = (true, \\"bar\\")) {})",
 }
 `;
 
@@ -9484,6 +17911,30 @@ Object {
 }
 `;
 
+exports[`#433 - espree.parse - async function namedFn(a, b = (i++, true)) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+    "b",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": undefined,
+    "b": "true",
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a, b",
+  "value": "(async function namedFn(a, b = (i++, true)) {})",
+}
+`;
+
 exports[`#434 - espree.parse - async (a, b = (i++, true)) => {} 1`] = `
 Object {
   "args": Array [
@@ -9505,6 +17956,54 @@ Object {
   "name": null,
   "params": "a, b",
   "value": "(async (a, b = (i++, true)) => {})",
+}
+`;
+
+exports[`#434 - espree.parse - async function namedFn(a = 1) {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "1",
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a",
+  "value": "(async function namedFn(a = 1) {})",
+}
+`;
+
+exports[`#435 - espree.parse - async (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) => {return a * 3} 1`] = `
+Object {
+  "args": Array [
+    "a",
+    "cb",
+    "restArgs",
+  ],
+  "body": "return a * 3",
+  "defaults": Object {
+    "a": "{foo: \\"ba)r\\", baz: 123}",
+    "cb": undefined,
+    "restArgs": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a, cb, restArgs",
+  "value": "(async (a = {foo: \\"ba)r\\", baz: 123}, cb, ...restArgs) => {return a * 3})",
 }
 `;
 
@@ -9552,6 +18051,54 @@ Object {
 }
 `;
 
+exports[`#436 - espree.parse - async (b, callback, ...restArgs) => {callback(null, b + 3)} 1`] = `
+Object {
+  "args": Array [
+    "b",
+    "callback",
+    "restArgs",
+  ],
+  "body": "callback(null, b + 3)",
+  "defaults": Object {
+    "b": undefined,
+    "callback": undefined,
+    "restArgs": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "b, callback, restArgs",
+  "value": "(async (b, callback, ...restArgs) => {callback(null, b + 3)})",
+}
+`;
+
+exports[`#437 - espree.parse - async (c) => {return c * 3} 1`] = `
+Object {
+  "args": Array [
+    "c",
+  ],
+  "body": "return c * 3",
+  "defaults": Object {
+    "c": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "c",
+  "value": "(async (c) => {return c * 3})",
+}
+`;
+
 exports[`#437 - espree.parse - async d => d * 355 * d 1`] = `
 Object {
   "args": Array [
@@ -9571,6 +18118,28 @@ Object {
   "name": null,
   "params": "d",
   "value": "(async d => d * 355 * d)",
+}
+`;
+
+exports[`#438 - espree.parse - async (...restArgs) => {return 321} 1`] = `
+Object {
+  "args": Array [
+    "restArgs",
+  ],
+  "body": "return 321",
+  "defaults": Object {
+    "restArgs": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "restArgs",
+  "value": "(async (...restArgs) => {return 321})",
 }
 `;
 
@@ -9596,6 +18165,24 @@ Object {
 }
 `;
 
+exports[`#439 - espree.parse - async () => {} 1`] = `
+Object {
+  "args": Array [],
+  "body": "",
+  "defaults": Object {},
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "",
+  "value": "(async () => {})",
+}
+`;
+
 exports[`#439 - espree.parse - async (a, b) => a + 3 + b 1`] = `
 Object {
   "args": Array [
@@ -9617,6 +18204,28 @@ Object {
   "name": null,
   "params": "a, b",
   "value": "(async (a, b) => a + 3 + b)",
+}
+`;
+
+exports[`#440 - espree.parse - async (a = (true, false)) => {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "false",
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "(async (a = (true, false)) => {})",
 }
 `;
 
@@ -9646,6 +18255,28 @@ Object {
 }
 `;
 
+exports[`#441 - espree.parse - async (a = (true, null)) => {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "null",
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "(async (a = (true, null)) => {})",
+}
+`;
+
 exports[`#441 - espree.parse - should return object with default values when invalid 1`] = `
 Object {
   "args": Array [],
@@ -9664,6 +18295,28 @@ Object {
 }
 `;
 
+exports[`#442 - espree.parse - async (a = (true, "bar")) => {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "\\"bar\\"",
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "(async (a = (true, \\"bar\\")) => {})",
+}
+`;
+
 exports[`#442 - espree.parse - should have '.isValid' and few '.is*'' hidden properties 1`] = `
 Object {
   "args": Array [],
@@ -9679,6 +18332,118 @@ Object {
   "name": null,
   "params": "",
   "value": "",
+}
+`;
+
+exports[`#443 - espree.parse - async (a, b = (i++, true)) => {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+    "b",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": undefined,
+    "b": "true",
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a, b",
+  "value": "(async (a, b = (i++, true)) => {})",
+}
+`;
+
+exports[`#444 - espree.parse - async (a = 1) => {} 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "",
+  "defaults": Object {
+    "a": "1",
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "(async (a = 1) => {})",
+}
+`;
+
+exports[`#445 - espree.parse - async (a) => a * 3 * a 1`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "a * 3 * a",
+  "defaults": Object {
+    "a": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": true,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a",
+  "value": "(async (a) => a * 3 * a)",
+}
+`;
+
+exports[`#446 - espree.parse - async d => d * 355 * d 1`] = `
+Object {
+  "args": Array [
+    "d",
+  ],
+  "body": "d * 355 * d",
+  "defaults": Object {
+    "d": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": true,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "d",
+  "value": "(async d => d * 355 * d)",
+}
+`;
+
+exports[`#447 - espree.parse - async e => {return e + 5235 / e} 1`] = `
+Object {
+  "args": Array [
+    "e",
+  ],
+  "body": "return e + 5235 / e",
+  "defaults": Object {
+    "e": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "e",
+  "value": "(async e => {return e + 5235 / e})",
 }
 `;
 
@@ -9765,6 +18530,221 @@ Object {
 `;
 
 exports[`#447 - espree.parse - should work for object methods 4`] = `
+Object {
+  "args": Array [
+    "a",
+    "cb",
+    "restArgs",
+  ],
+  "body": " return a * 3 ",
+  "defaults": Object {
+    "a": "{foo: 'ba)r', baz: 123}",
+    "cb": undefined,
+    "restArgs": undefined,
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "namedFn",
+  "params": "a, cb, restArgs",
+  "value": "({ namedFn (a = {foo: 'ba)r', baz: 123}, cb, ...restArgs) { return a * 3 } })",
+}
+`;
+
+exports[`#448 - espree.parse - async (a, b) => a + 3 + b 1`] = `
+Object {
+  "args": Array [
+    "a",
+    "b",
+  ],
+  "body": "a + 3 + b",
+  "defaults": Object {
+    "a": undefined,
+    "b": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": true,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "a, b",
+  "value": "(async (a, b) => a + 3 + b)",
+}
+`;
+
+exports[`#449 - espree.parse - async (x, y, ...restArgs) => console.log({ value: x * y }) 1`] = `
+Object {
+  "args": Array [
+    "x",
+    "y",
+    "restArgs",
+  ],
+  "body": "console.log({ value: x * y })",
+  "defaults": Object {
+    "restArgs": undefined,
+    "x": undefined,
+    "y": undefined,
+  },
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": true,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "x, y, restArgs",
+  "value": "(async (x, y, ...restArgs) => console.log({ value: x * y }))",
+}
+`;
+
+exports[`#450 - espree.parse - async ({x, y}) => {} 1`] = `
+Object {
+  "args": Array [
+    "x",
+    "y",
+  ],
+  "body": "",
+  "defaults": Object {},
+  "isAnonymous": true,
+  "isArrow": true,
+  "isAsync": true,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": true,
+  "name": null,
+  "params": "x, y",
+  "value": "(async ({x, y}) => {})",
+}
+`;
+
+exports[`#451 - espree.parse - should return object with default values when invalid 1`] = `
+Object {
+  "args": Array [],
+  "body": "",
+  "defaults": Object {},
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": false,
+  "name": null,
+  "params": "",
+  "value": "",
+}
+`;
+
+exports[`#452 - espree.parse - should have '.isValid' and few '.is*'' hidden properties 1`] = `
+Object {
+  "args": Array [],
+  "body": "",
+  "defaults": Object {},
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": false,
+  "isValid": false,
+  "name": null,
+  "params": "",
+  "value": "",
+}
+`;
+
+exports[`#457 - espree.parse - should work for object methods 1`] = `
+Object {
+  "args": Array [
+    "a",
+    "b",
+    "c",
+  ],
+  "body": "
+        return 123;
+      ",
+  "defaults": Object {
+    "a": undefined,
+    "b": undefined,
+    "c": undefined,
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "foo",
+  "params": "a, b, c",
+  "value": "({ foo(a, b, c) {
+        return 123;
+      } })",
+}
+`;
+
+exports[`#457 - espree.parse - should work for object methods 2`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "
+        return () => a;
+      ",
+  "defaults": Object {
+    "a": undefined,
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": false,
+  "isNamed": true,
+  "isValid": true,
+  "name": "bar",
+  "params": "a",
+  "value": "({ bar(a) {
+        return () => a;
+      } })",
+}
+`;
+
+exports[`#457 - espree.parse - should work for object methods 3`] = `
+Object {
+  "args": Array [
+    "a",
+  ],
+  "body": "
+        return yield a * 321;
+      ",
+  "defaults": Object {
+    "a": undefined,
+  },
+  "isAnonymous": false,
+  "isArrow": false,
+  "isAsync": false,
+  "isExpression": false,
+  "isGenerator": true,
+  "isNamed": true,
+  "isValid": true,
+  "name": "gen",
+  "params": "a",
+  "value": "({ *gen(a) {
+        return yield a * 321;
+      } })",
+}
+`;
+
+exports[`#457 - espree.parse - should work for object methods 4`] = `
 Object {
   "args": Array [
     "a",

--- a/@packages/parse-function/test/index.js
+++ b/@packages/parse-function/test/index.js
@@ -22,6 +22,7 @@ const fixtures = {
     'function (a = (true, "bar")) {}',
     'function (a, b = (i++, true)) {}',
     'function (a = 1) {}',
+    'function ({x, y}) {}',
   ],
   named: [
     'function namedFn (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3}',
@@ -34,6 +35,7 @@ const fixtures = {
     'function namedFn(a = (true, "bar")) {}',
     'function namedFn(a, b = (i++, true)) {}',
     'function namedFn(a = 1) {}',
+    'function namedFn({x, y}) {}',
   ],
   generators: [
     'function * namedFn (a = {foo: "ba)r", baz: 123}, cb, ...restArgs) {return a * 3}',
@@ -46,6 +48,7 @@ const fixtures = {
     'function * namedFn(a = (true, "bar")) {}',
     'function * namedFn(a, b = (i++, true)) {}',
     'function * namedFn(a = 1) {}',
+    'function * namedFn({x, y}) {}',
   ],
   arrows: [
     '(a = {foo: "ba)r", baz: 123}, cb, ...restArgs) => {return a * 3}',

--- a/@packages/parse-function/test/index.js
+++ b/@packages/parse-function/test/index.js
@@ -63,6 +63,7 @@ const fixtures = {
     'e => {return e + 5235 / e}',
     '(a, b) => a + 3 + b',
     '(x, y, ...restArgs) => console.log({ value: x * y })',
+    '({x, y}) => {}',
   ],
 };
 


### PR DESCRIPTION
Added parse arguments of function like:
```
({x, y}) => {}
```

Which return result.args = ` ['x', 'y']`

@tunnckoCore Can you help me with tests? 